### PR TITLE
Fix missing 16.04 packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,10 @@ set(TIDE_MAINTAINER "Blue Brain Project <bbp-open-source@googlegroups.com>")
 set(TIDE_LICENSE BSD)
 set(TIDE_DEB_DEPENDS  libboost-date-time-dev libboost-program-options-dev
   libboost-serialization-dev libboost-test-dev libopenmpi-dev openmpi-bin
-  qtbase5-dev qtdeclarative5-dev libqt5svg5-dev libqt5webkit5-dev
-  libqt5xmlpatterns5-dev libqt5x11extras5-dev libpoppler-qt5-dev
-  libavutil-dev libavformat-dev libavcodec-dev libswscale-dev libxmu-dev)
+  qtbase5-dev qtbase5-private-dev qtdeclarative5-dev qtdeclarative5-private-dev
+  libqt5svg5-dev libqt5webkit5-dev libqt5xmlpatterns5-dev libqt5x11extras5-dev
+  libpoppler-qt5-dev libavutil-dev libavformat-dev libavcodec-dev
+  libswscale-dev libxmu-dev)
 set(TIDE_PORT_DEPENDS boost ffmpeg mpich-devel qt5)
 
 include(Common)


### PR DESCRIPTION
Without these installed, the cmake run fails ungracefully since VirtualKeyboard does not use common_find_package on a missing required dependency :(