### PR TITLE
Webengine improvements [DISCL-388]

### DIFF
--- a/apps/Webbrowser/Webbrowser.h
+++ b/apps/Webbrowser/Webbrowser.h
@@ -46,6 +46,8 @@
 
 #include <QGuiApplication>
 
+class HtmlSelectReplacer;
+
 /**
  * Offscreen application which streams a Qml Webbrowser using deflect::Qt API.
  */
@@ -64,6 +66,7 @@ private slots:
 private:
     std::unique_ptr<deflect::qt::QmlStreamer> _qmlStreamer;
     QQuickItem* _webengine = nullptr; // reference, don't free
+    std::unique_ptr<HtmlSelectReplacer> _selectReplacer;
 
     bool event( QEvent* event ) final;
 };

--- a/apps/Webbrowser/qml/HtmlSelectReplacer.js
+++ b/apps/Webbrowser/qml/HtmlSelectReplacer.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, EPFL/Blue Brain Project
+//                          Raphael Dumusc <raphael.dumusc@epfl.ch>
+
+/**
+ * Class to replace the system html select elements of a WebEngineView.
+ */
+function HtmlSelectReplacer(webengine) {
+    this.webengine = webengine;
+}
+
+// Load the necessary scripts and replace the select elements.
+// Call this when the page has finished loading.
+HtmlSelectReplacer.prototype.process = function() {
+    this.findSelectElements();
+}
+
+HtmlSelectReplacer.prototype.findSelectElements = function() {
+    var hasSelectElements = "document.getElementsByTagName('select').length > 0";
+    this.webengine.runJavaScript(hasSelectElements, (function(result) {
+        if (result)
+            this.checkJQuery();
+    }).bind(this));
+}
+
+HtmlSelectReplacer.prototype.checkJQuery = function() {
+    var hasJQuery = "window.jQuery ? true : false";
+    this.webengine.runJavaScript(hasJQuery, (function(result) {
+        if (result)
+            this.checkJQueryUI();
+        else
+            this.loadJQuery();
+    }).bind(this));
+}
+
+HtmlSelectReplacer.prototype.loadJQuery = function() {
+    this.webengine.runJavaScript(htmlselect.jQuery,
+                                 this.checkJQueryUI.bind(this));
+}
+
+HtmlSelectReplacer.prototype.checkJQueryUI = function() {
+    var hasJQueryUI = "window.jQuery.ui ? true : false"
+    this.webengine.runJavaScript(hasJQueryUI, (function(result) {
+        if (result)
+            this.loadSelectboxit()
+        else
+            this.loadJQueryUI()
+    }).bind(this));
+}
+
+HtmlSelectReplacer.prototype.loadJQueryUI = function() {
+    this.webengine.runJavaScript(htmlselect.jQueryUI,
+                                 this.loadSelectboxit.bind(this));
+}
+
+HtmlSelectReplacer.prototype.loadSelectboxit = function() {
+    this.webengine.runJavaScript(htmlselect.selectboxit,
+                                 this.loadCssUsingJQuery.bind(this));
+}
+
+HtmlSelectReplacer.prototype.loadCssUsingJQuery = function() {
+    this.webengine.runJavaScript(htmlselect.selectboxitCss,
+                                 this.replaceSelectElements.bind(this));
+}
+
+HtmlSelectReplacer.prototype.replaceSelectElements = function() {
+    this.webengine.runJavaScript(htmlselect.selectboxitReplace);
+}

--- a/apps/Webbrowser/qml/Webengine.qml
+++ b/apps/Webbrowser/qml/Webengine.qml
@@ -2,13 +2,14 @@
 //                     Raphael Dumusc <raphael.dumusc@epfl.ch>
 
 import QtQuick 2.0
-import QtWebEngine 1.0
+import QtWebEngine 1.1
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import QtGraphicalEffects 1.0
 
 import "qrc:/qml/core/."
 import "qrc:/qml/core/style.js" as Style
+import "HtmlSelectReplacer.js" as HSR
 
 Item {
     width: 640
@@ -75,10 +76,21 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
 
+        settings.localContentCanAccessRemoteUrls: true
+        settings.pluginsEnabled: true
+
         Connections {
             target: deflectgestures
             onSwipeLeft: webengine.goBack()
             onSwipeRight: webengine.goForward()
+        }
+
+        property var replacer: ({})
+        Component.onCompleted: replacer = new HSR.HtmlSelectReplacer(webengine)
+
+        onLoadingChanged: {
+            if (loadRequest.status === WebEngineView.LoadSucceededStatus)
+                webengine.replacer.process()
         }
     }
 

--- a/apps/Webbrowser/resources.qrc
+++ b/apps/Webbrowser/resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/qml">
         <file>qml/Webengine.qml</file>
+        <file>qml/HtmlSelectReplacer.js</file>
     </qresource>
 </RCC>

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,11 @@ Changelog {#changelog}
 
 # Release 1.2 (git master)
 
+* [92](https://github.com/BlueBrain/Tide/pull/92):
+  Improvements to the WebEngine webbrowser (Qt 5.6 or later):
+  - Plugins enabled (flash)
+  - Replace "select" system drop-down lists with html equivalents (as was
+    already done for the Webkit webbrowser)
 * [90](https://github.com/BlueBrain/Tide/pull/90):
   The fullscreen mode has some new features:
   - Users can now enlarge and pan contents (without the need to use the zoom)

--- a/tide/core/scene/WebbrowserHistory.cpp
+++ b/tide/core/scene/WebbrowserHistory.cpp
@@ -52,11 +52,10 @@ WebbrowserHistory::WebbrowserHistory( const QWebHistory& history )
 #endif
 
 WebbrowserHistory::WebbrowserHistory( std::vector<QString>&& items_,
-                                      const int currentItemIndex_ )
-{
-    _items = items_;
-    _currentItemIndex = currentItemIndex_;
-}
+                                      const size_t currentItemIndex_ )
+    : _items{ items_ }
+    , _currentItemIndex{ currentItemIndex_ }
+{}
 
 size_t WebbrowserHistory::currentItemIndex() const
 {

--- a/tide/core/scene/WebbrowserHistory.h
+++ b/tide/core/scene/WebbrowserHistory.h
@@ -56,7 +56,7 @@ public:
 #ifdef TIDE_USE_QT5WEBKITWIDGETS
     explicit WebbrowserHistory( const QWebHistory& history );
 #endif
-    WebbrowserHistory( std::vector<QString>&& items, int currentItemIndex );
+    WebbrowserHistory( std::vector<QString>&& items, size_t currentItemIndex );
 
     const std::vector<QString>& items() const;
     size_t currentItemIndex() const;

--- a/tide/master/CMakeLists.txt
+++ b/tide/master/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND TIDEMASTER_PUBLIC_HEADERS
   control/LayoutEngine.h
   control/PixelStreamController.h
   control/ZoomController.h
+  localstreamer/HtmlSelectReplacer.h
   localstreamer/CommandLineOptions.h
   localstreamer/PixelStreamerLauncher.h
   localstreamer/PixelStreamerType.h
@@ -60,6 +61,7 @@ list(APPEND TIDEMASTER_SOURCES
   control/LayoutEngine.cpp
   control/PixelStreamController.cpp
   control/ZoomController.cpp
+  localstreamer/HtmlSelectReplacer.cpp
   localstreamer/CommandLineOptions.cpp
   localstreamer/PixelStreamerLauncher.cpp
   localstreamer/PixelStreamerType.cpp

--- a/tide/master/localstreamer/HtmlSelectReplacer.h
+++ b/tide/master/localstreamer/HtmlSelectReplacer.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2014-2016, EPFL/Blue Brain Project                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,44 +37,41 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#ifndef WEBKITHTMLSELECTREPLACER_H
-#define WEBKITHTMLSELECTREPLACER_H
+#ifndef HTMLSELECTREPLACER_H
+#define HTMLSELECTREPLACER_H
 
-#include "HtmlSelectReplacer.h"
-#include <QWebView>
+#include <QObject>
+#include <QString>
 
 /**
- * Substitutes all \<select\> elements on a webpage by equivalent HTML lists.
- *
- * This class is useful for offscreen webbrowsers where the system list elements
- * are not working and may even cause a crash.
- *
- * It works by modifying the DOM using Javascript after the page has finished
- * loading.
+ * This class provides the necessary scripts (based on jQuery and SelectBoxIt)
+ * to substitute all \<select\> elements on a webpage by equivalent HTML lists.
  */
-class WebkitHtmlSelectReplacer
+class HtmlSelectReplacer : public QObject
 {
-public:
-    /**
-     * Constructor.
-     * @param webView The QWebView on which to operate.
-     */
-    WebkitHtmlSelectReplacer( QWebView& webView );
+    Q_OBJECT
+    Q_DISABLE_COPY( HtmlSelectReplacer )
 
-    /**
-     * Replace all \<select\> elements by HTML equivalents.
-     *
-     * It is only useful to call this if new \<select\> elements have been
-     * dynamically added *after* the page was loaded.
-     */
-    void replaceAllSelectElements();
+    Q_PROPERTY( QString jQuery READ getJQuery CONSTANT )
+    Q_PROPERTY( QString jQueryUI READ getJQueryUI CONSTANT )
+    Q_PROPERTY( QString selectboxit READ getSelectboxit CONSTANT )
+    Q_PROPERTY( QString selectboxitCss READ getSelectboxitCss CONSTANT )
+    Q_PROPERTY( QString selectboxitReplace READ getSelectboxitReplace CONSTANT )
+
+public:
+    HtmlSelectReplacer();
+
+    const QString& getJQuery() const;
+    const QString& getJQueryUI() const;
+    const QString& getSelectboxit() const;
+    const QString& getSelectboxitCss() const;
+    const QString& getSelectboxitReplace() const;
 
 private:
-    QWebView& _webView;
-    HtmlSelectReplacer _replacer;
-
-    void _loadScripts();
-    QVariant _evaluateJavascript( const QString& script );
+    QString _jQuery;
+    QString _jQueryUI;
+    QString _selectboxit;
+    QString _selectboxitCss;
 };
 
 #endif


### PR DESCRIPTION
- Plugins enabled (flash)
- Replace "select" system drop-down lists with html equivalents (as was
  already done for the Webkit webbrowser)
- Transmit full navigation history via Deflect