### PR TITLE
Multi-threaded thumbnail provider for Launcher [DISCL-369]

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git 009f72c
+# CMake/common https://github.com/Eyescale/CMake.git 11ee9c1

--- a/apps/Launcher/Launcher.cpp
+++ b/apps/Launcher/Launcher.cpp
@@ -87,7 +87,11 @@ Launcher::Launcher( int& argc, char* argv[] )
     item->setProperty( "rootSessionsFolder", config.getSessionsDir( ));
 
     QQmlEngine* engine = _qmlStreamer->getQmlEngine();
+#if TIDE_ASYNC_THUMBNAIL_PROVIDER
+    engine->addImageProvider( thumbnailProviderId, new AsyncThumbnailProvider );
+#else
     engine->addImageProvider( thumbnailProviderId, new ThumbnailProvider );
+#endif
     engine->rootContext()->setContextProperty( "fileInfo", &_fileInfoHelper );
 
     // DemoLauncher setup

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.2 (git master)
 
+* [100](https://github.com/BlueBrain/Tide/pull/100):
+  The Launcher can generate thumbnails much faster (requires Qt 5.6.3 or 5.7.1).
 * [97](https://github.com/BlueBrain/Tide/pull/97):
   Webbrowsers can be saved and restored from sessions and display the page title
   in their title bar.

--- a/tide/core/thumbnail/ThumbnailProvider.cpp
+++ b/tide/core/thumbnail/ThumbnailProvider.cpp
@@ -42,6 +42,7 @@
 
 #include "thumbnail.h"
 
+#include <QCache>
 #include <QDateTime>
 #include <QFileInfo>
 #include <QImageReader>
@@ -51,67 +52,151 @@
 namespace
 {
 const int cacheMaxSize = 200;
-const QString cacheModificationDateKey( "lastModificationDate" );
-const char* folderImg = "qrc:/img/folder.png";
-const char* unknownFileImg = "qrc:/img/unknownfile.png";
+const QString cacheModificationDateKey{ "lastModificationDate" };
+const QString folderImg{ ":/img/folder.png" };
+const QString unknownFileImg{ ":/img/unknownfile.png" };
 }
+
+QImage _getPlaceholderImage( const QString& filename )
+{
+    const auto fileInfo = QFileInfo{ filename };
+    if( fileInfo.isDir( ))
+    {
+        static QImage im{ folderImg };
+        assert( !im.isNull( ));
+        return im;
+    }
+
+    static QImage im{ unknownFileImg };
+    assert( !im.isNull( ));
+    return im;
+}
+
+class ThumbnailCache : public QCache<QString, QImage>
+{
+public:
+    ThumbnailCache()
+    {
+        setMaxCost( cacheMaxSize );
+    }
+
+    bool hasValidImage( const QString& filename ) const
+    {
+        if( !contains( filename ))
+            return false;
+
+        return QFileInfo{ filename }.lastModified().toString() ==
+                           object( filename )->text( cacheModificationDateKey );
+    }
+
+    void insertImage( const QImage& image, const QString& filename )
+    {
+        // QCache requires a <T>* and takes ownership, a new QImage is required
+        auto cacheImage = new QImage{ image };
+        cacheImage->setText( cacheModificationDateKey,
+                             QFileInfo{ filename }.lastModified().toString( ));
+        insert( filename, cacheImage );
+    }
+};
 
 ThumbnailProvider::ThumbnailProvider( const QSize defaultSize )
     : QQuickImageProvider( QQuickImageProvider::Image,
                            QQuickImageProvider::ForceAsynchronousImageLoading )
     , _defaultSize( defaultSize )
-{
-    _cache.setMaxCost( cacheMaxSize );
-}
+    , _cache( new ThumbnailCache )
+{}
 
 QImage ThumbnailProvider::requestImage( const QString& filename, QSize* size,
                                         const QSize& requestedSize )
 {
-    const QSize newSize( requestedSize.height() > 0 ?
+    const QSize newSize{ requestedSize.height() > 0 ?
                              requestedSize.height() : _defaultSize.height(),
                          requestedSize.width() > 0 ?
-                             requestedSize.width() : _defaultSize.width( ));
+                             requestedSize.width() : _defaultSize.width() };
     if( size )
         *size = newSize;
 
-    if( _isImageInCache( filename ))
-        return *_cache[filename];
+    if( _cache->hasValidImage( filename ))
+        return *_cache->object( filename );
 
     const auto image = thumbnail::create( filename, newSize );
-    if( !image.isNull( ))
-    {
-        // QCache requires a <T>* and takes ownership, a new QImage is required
-        QImage* cacheImage = new QImage( image );
-        cacheImage->setText( cacheModificationDateKey,
-                             QFileInfo( filename ).lastModified().toString( ));
-        _cache.insert( filename, cacheImage );
-        return image;
-    }
+    if( image.isNull( )) // should never happen
+        return _getPlaceholderImage( filename );
 
-    // Thumbnail generation failed, return a placeholder
-    const QFileInfo fileInfo( filename );
-    if( fileInfo.isFile( ))
-    {
-        static QImage im( unknownFileImg );
-        assert( !im.isNull( ));
-        return im;
-    }
-    if( fileInfo.isDir( ))
-    {
-        static QImage im( folderImg );
-        assert( !im.isNull( ));
-        return im;
-    }
-
-    return image; // Silence compiler warning
+    _cache->insertImage( image, filename );
+    return image;
 }
 
-bool ThumbnailProvider::_isImageInCache( const QString& filename ) const
+
+#if TIDE_ASYNC_THUMBNAIL_PROVIDER
+#include <QThreadPool>
+
+class AsyncImageResponse : public QQuickImageResponse, public QRunnable
 {
-    if( !_cache.contains( filename ))
-        return false;
+public:
+    AsyncImageResponse( std::function<QImage()> getImageFunc )
+        : _getImageFunc( getImageFunc )
+    {
+        setAutoDelete( false );
+    }
 
-    const QFileInfo info( filename );
-    return info.lastModified().toString() ==
-            _cache.object( filename )->text( cacheModificationDateKey );
+    QQuickTextureFactory* textureFactory() const final
+    {
+        return QQuickTextureFactory::textureFactoryForImage( _image );
+    }
+
+    void cancel() final
+    {
+        _canceled = true;
+    }
+
+    void run() final
+    {
+        if( !_canceled )
+            _image = _getImageFunc();
+        emit finished();
+    }
+
+private:
+    std::function<QImage()> _getImageFunc;
+    QImage _image;
+    bool _canceled = false;
+};
+
+
+AsyncThumbnailProvider::AsyncThumbnailProvider( const QSize defaultSize )
+    : _defaultSize( defaultSize )
+    , _cache( new ThumbnailCache )
+{}
+
+QQuickImageResponse*
+AsyncThumbnailProvider::requestImageResponse( const QString& filename,
+                                              const QSize& requestedSize )
+{
+    const QSize size{ requestedSize.height() > 0 ?
+                         requestedSize.height() : _defaultSize.height(),
+                      requestedSize.width() > 0 ?
+                           requestedSize.width() : _defaultSize.width() };
+
+    auto response = new AsyncImageResponse( [this, filename, size]()
+    {
+        {
+            const std::lock_guard<std::mutex> lock{ _mutex };
+            if( _cache->hasValidImage( filename ))
+                return *_cache->object( filename );
+        }
+
+        const auto image = thumbnail::create( filename, size );
+        if( image.isNull( )) // should never happen
+            return _getPlaceholderImage( filename );
+
+        const std::lock_guard<std::mutex> lock{ _mutex };
+        _cache->insertImage( image, filename );
+        return image;
+    });
+
+    QThreadPool::globalInstance()->start( response );
+    return response;
 }
+
+#endif


### PR DESCRIPTION
This greatly increases the speed of generating preview images.

The QQuickAsyncImageProvider was introduced in Qt 5.6, but because
of a bug (https://bugreports.qt.io/browse/QTBUG-56056) it
segfaults on Qt versions prior to 5.6.3 or 5.7.1.