### PR TITLE
Remove async send for Whiteboard (threading issues), other minor improvements

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git 11ee9c1
+# CMake/common https://github.com/Eyescale/CMake.git 72e7e1e

--- a/CMake/GitExternal.cmake
+++ b/CMake/GitExternal.cmake
@@ -8,7 +8,7 @@
 #    update target to bump the tag to the master revision by
 #    recreating .gitexternals.
 #  * Provides function
-#      git_external(<directory> <giturl> <gittag> [VERBOSE,SHALLOW]
+#      git_external(<directory> <giturl> <gittag> [VERBOSE]
 #        [RESET <files>])
 #    which will check out directory in CMAKE_SOURCE_DIR (if relative)
 #    or in the given absolute path using the given repository and tag
@@ -18,11 +18,6 @@
 #  VERBOSE, when present, this option tells the function to output
 #    information about what operations are being performed by git on
 #    the repo.
-#  SHALLOW, when present, causes a shallow clone of depth 1 to be made
-#    of the specified repo. This may save considerable memory/bandwidth
-#    when only a specific branch of a repo is required and the full history
-#    is not required. Note that the SHALLOW option will only work for a branch
-#    or tag and cannot be used for an arbitrary SHA.
 #  OPTIONAL, when present, this option makes this operation optional.
 #    The function will output a warning and return if the repo could not be
 #    cloned.
@@ -69,15 +64,8 @@ macro(GIT_EXTERNAL_MESSAGE msg)
   endif()
 endmacro()
 
-# utility function for printing a list with custom separator
-function(JOIN VALUES GLUE OUTPUT)
-  string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
-  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") #fixes escaping
-  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
-endfunction()
-
 function(GIT_EXTERNAL DIR REPO tag)
-  cmake_parse_arguments(GIT_EXTERNAL_LOCAL "VERBOSE;SHALLOW;OPTIONAL" "" "RESET" ${ARGN})
+  cmake_parse_arguments(GIT_EXTERNAL_LOCAL "VERBOSE;OPTIONAL" "" "RESET" ${ARGN})
   set(TAG ${tag})
   if(GIT_EXTERNAL_TAG AND "${tag}" MATCHES "^[0-9a-f]+$")
     set(TAG ${GIT_EXTERNAL_TAG})
@@ -105,16 +93,9 @@ function(GIT_EXTERNAL DIR REPO tag)
 
   if(NOT EXISTS "${DIR}")
     # clone
-    set(_clone_options --recursive)
-    if(GIT_EXTERNAL_LOCAL_SHALLOW)
-      list(APPEND _clone_options --depth 1 --branch ${TAG})
-    else()
-      set(_msg_tag "[${TAG}]")
-    endif()
-    JOIN("${_clone_options}" " " _msg_text)
-    message(STATUS "git clone ${_msg_text} ${REPO} ${DIR} ${_msg_tag}")
+    message(STATUS "git clone --recursive ${REPO} ${DIR} [${TAG}]")
     execute_process(
-      COMMAND "${GIT_EXECUTABLE}" clone ${_clone_options} ${REPO} ${DIR}
+      COMMAND "${GIT_EXECUTABLE}" clone --recursive ${REPO} ${DIR}
       RESULT_VARIABLE nok ERROR_VARIABLE error
       WORKING_DIRECTORY "${GIT_EXTERNAL_DIR}")
     if(nok)
@@ -127,21 +108,8 @@ function(GIT_EXTERNAL DIR REPO tag)
     endif()
 
     # checkout requested tag
-    if(NOT GIT_EXTERNAL_LOCAL_SHALLOW)
-      execute_process(
-        COMMAND "${GIT_EXECUTABLE}" checkout -q "${TAG}"
-        RESULT_VARIABLE nok ERROR_VARIABLE error
-        WORKING_DIRECTORY "${DIR}")
-      if(nok)
-        message(FATAL_ERROR "git checkout ${TAG} in ${DIR} failed: ${error}\n")
-      endif()
-    endif()
-
-    # checkout requested tag
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" checkout -q "${TAG}"
-      RESULT_VARIABLE nok ERROR_VARIABLE error
-      WORKING_DIRECTORY "${DIR}")
+    execute_process(COMMAND "${GIT_EXECUTABLE}" checkout -q "${TAG}"
+      RESULT_VARIABLE nok ERROR_VARIABLE error WORKING_DIRECTORY "${DIR}")
     if(nok)
       message(FATAL_ERROR "git checkout ${TAG} in ${DIR} failed: ${error}\n")
     endif()

--- a/apps/Whiteboard/Whiteboard.cpp
+++ b/apps/Whiteboard/Whiteboard.cpp
@@ -61,7 +61,6 @@ Whiteboard::Whiteboard( int& argc, char* argv[] )
     _qmlStreamer.reset( new deflect::qt::QmlStreamer( deflectQmlFile,
                                                       deflectHost,
                                                       deflectStreamId ));
-    _qmlStreamer->useAsyncSend( true );
 
     connect( _qmlStreamer.get(), &deflect::qt::QmlStreamer::streamClosed,
              this, &QCoreApplication::quit );

--- a/apps/Whiteboard/qml/whiteboard.qml
+++ b/apps/Whiteboard/qml/whiteboard.qml
@@ -316,8 +316,8 @@ Item {
                 }
                 Rectangle {
                     anchors.fill: parent
-                    color: "lightsteelblue"
-                    opacity: 0.3
+                    color: "black"
+                    opacity: 0.7
                     visible: parent.enabled
                 }
             }
@@ -493,55 +493,55 @@ Item {
                     wrapMode: Text.Wrap
                 }
                 Row {
-                	anchors.verticalCenter: parent.verticalCenter
-                	anchors.horizontalCenter: parent.horizontalCenter
-                	spacing: 10
-                	height: 50
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: 10
+                    height: 50
 
-	                Button {
-	                    id: buttonOK
-	                    implicitWidth: 100
-	                    implicitHeight: 50
-	                    style: ButtonStyle {
-	                        label: Text {
-	                            renderType: Text.NativeRendering
-	                            horizontalAlignment: Text.AlignHCenter
-	                            font.pointSize: control.height * 0.3
-	                            verticalAlignment: Text.AlignVCenter
-	                            text: "OK"
-	                            color: control.enabled ? "black" : "gray"
-	                        }
-	                    }
-	                    onClicked: saveCanvas()
-	                }
-	                Button {
-	                    id: buttonCancel
-	                    visible: buttonOK.visible
-	                    implicitWidth: 100
-	                    implicitHeight: 50
-	                    style: ButtonStyle {
-	                        label: Text {
-	                            renderType: Text.NativeRendering
-	                            font.pointSize: control.height * 0.3
-	                            horizontalAlignment: Text.AlignHCenter
-	                            verticalAlignment: Text.AlignVCenter
-	                            text: "Cancel"
-	                            color: control.enabled ? "black" : "gray"
-	                        }
-	                    }
-	                    onClicked: cancelSave()
-	                }
-	            }
+                    Button {
+                        id: buttonOK
+                        implicitWidth: 100
+                        implicitHeight: 50
+                        style: ButtonStyle {
+                            label: Text {
+                                renderType: Text.NativeRendering
+                                horizontalAlignment: Text.AlignHCenter
+                                font.pointSize: control.height * 0.3
+                                verticalAlignment: Text.AlignVCenter
+                                text: "OK"
+                                color: control.enabled ? "black" : "gray"
+                            }
+                        }
+                        onClicked: saveCanvas()
+                    }
+                    Button {
+                        id: buttonCancel
+                        visible: buttonOK.visible
+                        implicitWidth: 100
+                        implicitHeight: 50
+                        style: ButtonStyle {
+                            label: Text {
+                                renderType: Text.NativeRendering
+                                font.pointSize: control.height * 0.3
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                                text: "Cancel"
+                                color: control.enabled ? "black" : "gray"
+                            }
+                        }
+                        onClicked: cancelSave()
+                    }
+                }
             }
-        }
-        Loader {
-            id: virtualKeyboard
-            source: "qrc:/virtualkeyboard/InputPanel.qml"
-            anchors.top: textInput.bottom
-            anchors.right: savePanel.right
-            anchors.left: savePanel.left
-            anchors.bottom: savePanel.bottom
-            visible: Qt.inputMethod.visible ? true : false
+            Loader {
+                id: virtualKeyboard
+                source: "qrc:/virtualkeyboard/InputPanel.qml"
+                anchors.top: textInput.bottom
+                anchors.right: savePanel.right
+                anchors.left: savePanel.left
+                anchors.bottom: savePanel.bottom
+                visible: Qt.inputMethod.visible ? true : false
+            }
         }
     }
 }

--- a/tide/master/network/MasterFromWallChannel.cpp
+++ b/tide/master/network/MasterFromWallChannel.cpp
@@ -47,6 +47,11 @@ MasterFromWallChannel::MasterFromWallChannel( MPIChannelPtr mpiChannel )
     : _mpiChannel( mpiChannel )
     , _processMessages( true )
 {
+    if( _mpiChannel->getSize() < 2 )
+    {
+        put_flog( LOG_WARN, "Channel has no Wall receiver" );
+        _processMessages = false;
+    }
 }
 
 void MasterFromWallChannel::processMessages()


### PR DESCRIPTION
The async send, used together with a QApplication, generates and endless flow of:
`qWarning: QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread`

This seems to be linked to the use of a QDataStream in deflect::Socket::send(). The same warning is alos printed from Webbrowser::_sendData(). Looks like the QTcpSocket really dosen't like being called from multiple threads. We have to look at a fix or work around in Deflect.