### PR TITLE
Fullscreen mode: fix a subtle misbehaviour of double-tap with certain contents

### DIFF
--- a/tide/core/resources/BaseContentWindow.qml
+++ b/tide/core/resources/BaseContentWindow.qml
@@ -127,21 +127,24 @@ Rectangle {
             }
         }
         Behavior on posX {
-            enabled: contentwindow.focused
+            id: transitionBehaviour
+            enabled: contentwindow.focused ||
+                     (contentwindow.fullscreen &&
+                      contentwindow.state === ContentWindow.NONE)
             NumberAnimation {
                 duration: Style.focusTransitionTime
                 easing.type: Easing.InOutQuad
             }
         }
         Behavior on posY {
-            enabled: contentwindow.focused
+            enabled: transitionBehaviour.enabled
             NumberAnimation {
                 duration: Style.focusTransitionTime
                 easing.type: Easing.InOutQuad
             }
         }
         Behavior on width {
-            enabled: contentwindow.focused
+            enabled: transitionBehaviour.enabled
             NumberAnimation {
                 id: widthAnimation
                 duration: Style.focusTransitionTime
@@ -149,7 +152,7 @@ Rectangle {
             }
         }
         Behavior on height {
-            enabled: contentwindow.focused
+            enabled: transitionBehaviour.enabled
             NumberAnimation {
                 id: heightAnimation
                 duration: Style.focusTransitionTime

--- a/tide/master/control/ContentWindowController.cpp
+++ b/tide/master/control/ContentWindowController.cpp
@@ -211,10 +211,10 @@ void ContentWindowController::toogleFullscreenMaxSize()
         return;
 
     const auto windowSize = _getCoordinates().size();
-    if( windowSize < _displayGroup.size( ))
-        adjustSize( SizeState::SIZE_FULLSCREEN_MAX );
-    else
+    if( windowSize > _displayGroup.size( ))
         adjustSize( SizeState::SIZE_FULLSCREEN );
+    else
+        adjustSize( SizeState::SIZE_FULLSCREEN_MAX );
 }
 
 void ContentWindowController::moveTo( const QPointF& position,


### PR DESCRIPTION
If the content was too small to reach or exceed SIZE_FULLSCREEN_MAX, then the
double-tap action would keep trying to maximize it. The only way to go back
to SIZE_FULLSCREEN was by pinching out. With this change the double-tap
alternates between the two fullscreen modes as expected.