### PR TITLE
Added YUV texture support for faster movie rendering [DISCL-353]

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,9 @@ Changelog {#changelog}
 
 # Release 1.3 (git master)
 
+* [124](https://github.com/BlueBrain/Tide/pull/124):
+  Faster movie playback through direct rendering of YUV frames on GPU.
+  Performance improved by ~60% (10->16fps) on a test 8K "webm" movie.
 * [120](https://github.com/BlueBrain/Tide/pull/120):
   User can now upload content to the local file system via the web interface.
 * [122](https://github.com/BlueBrain/Tide/pull/122):

--- a/tide/core/CMakeLists.txt
+++ b/tide/core/CMakeLists.txt
@@ -14,7 +14,6 @@ set(TIDECORE_LINK_LIBRARIES
     ${Boost_LIBRARIES}
     ${MPI_CXX_LIBRARIES}
   PRIVATE
-    ${FFMPEG_LIBRARIES}
     Qt5::Concurrent
     Qt5::Svg
 )
@@ -37,6 +36,9 @@ if(TIDE_ENABLE_MOVIE_SUPPORT)
     data/FFMPEGVideoStream.cpp
     scene/MovieContent.cpp
     thumbnail/MovieThumbnailGenerator.cpp
+  )
+  list(APPEND TIDECORE_LINK_LIBRARIES
+    PRIVATE ${FFMPEG_LIBRARIES}
   )
 endif()
 
@@ -159,6 +161,7 @@ list(APPEND TIDECORE_PUBLIC_HEADERS
   thumbnail/ThumbnailGenerator.h
   thumbnail/ThumbnailProvider.h
   types.h
+  yuv.h
   ZoomHelper.h
 )
 
@@ -200,6 +203,7 @@ list(APPEND TIDECORE_SOURCES
   thumbnail/ThumbnailGenerator.cpp
   thumbnail/ThumbnailGeneratorFactory.cpp
   thumbnail/ThumbnailProvider.cpp
+  yuv.cpp
   ZoomHelper.cpp
   resources/core.qrc
 )

--- a/tide/core/CMakeLists.txt
+++ b/tide/core/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TIDECORE_LINK_LIBRARIES
 
 if(TIDE_ENABLE_MOVIE_SUPPORT)
   list(APPEND TIDECORE_PUBLIC_HEADERS
+    data/FFMPEGDefines.h
     data/FFMPEGFrame.h
     data/FFMPEGMovie.h
     data/FFMPEGPicture.h

--- a/tide/core/data/FFMPEGDefines.h
+++ b/tide/core/data/FFMPEGDefines.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,45 +37,20 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#ifndef FFMPEGFRAME_H
-#define FFMPEGFRAME_H
+#ifndef FFMPEGDEFINES_H
+#define FFMPEGDEFINES_H
 
-#include "FFMPEGDefines.h"
+// Must be included before any other FFMPEG header, specifically for Linux build
+#ifdef __cplusplus
+    #ifndef __STDC_CONSTANT_MACROS
+        #define __STDC_CONSTANT_MACROS
+    #endif
 
-extern "C"
-{
-    #include <libavcodec/avcodec.h>
-    #include <libavutil/mem.h>
-}
+    #ifdef _STDINT_H
+        #undef _STDINT_H
+    #endif
 
-/** A frame of an FFMPEG movie. */
-class FFMPEGFrame
-{
-public:
-    /** Constructor. */
-    FFMPEGFrame();
-
-    /** Destructor. */
-    ~FFMPEGFrame();
-
-    /** @return the width of the image. */
-    int getWidth() const;
-
-    /** @return the height of the image. */
-    int getHeight() const;
-
-    /** @return the timestamp of the frame. */
-    int64_t getTimestamp() const;
-
-    /** Get the FFMPEG frame. */
-    AVFrame& getAVFrame();
-    const AVFrame& getAVFrame() const;
-
-    /** @return the pixel format of the FFMPEG frame. */
-    AVPixelFormat getAvPixelFormat() const;
-
-private:
-    AVFrame* _avFrame;
-};
+    #include <stdint.h>
+#endif
 
 #endif

--- a/tide/core/data/FFMPEGFrame.cpp
+++ b/tide/core/data/FFMPEGFrame.cpp
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -39,7 +39,6 @@
 
 #include "FFMPEGFrame.h"
 
-#include <QOpenGLFunctions>
 #include "log.h"
 
 FFMPEGFrame::FFMPEGFrame()
@@ -58,6 +57,21 @@ FFMPEGFrame::~FFMPEGFrame()
     av_free( _avFrame );
 }
 
+int FFMPEGFrame::getWidth() const
+{
+    return _avFrame->width;
+}
+
+int FFMPEGFrame::getHeight() const
+{
+    return _avFrame->height;
+}
+
+const uint8_t* FFMPEGFrame::getData( const uint texture ) const
+{
+    return _avFrame->data[texture];
+}
+
 int64_t FFMPEGFrame::getTimestamp() const
 {
     return _avFrame->pkt_dts;
@@ -73,22 +87,7 @@ const AVFrame& FFMPEGFrame::getAVFrame() const
     return *_avFrame;
 }
 
-const uint8_t* FFMPEGFrame::getData() const
+AVPixelFormat FFMPEGFrame::getAvPixelFormat() const
 {
-    return _avFrame->data[0];
-}
-
-uint FFMPEGFrame::getFormat() const
-{
-    return GL_RGBA;
-}
-
-int FFMPEGFrame::getWidth() const
-{
-    return _avFrame->width;
-}
-
-int FFMPEGFrame::getHeight() const
-{
-    return _avFrame->height;
+    return AVPixelFormat(_avFrame->format);
 }

--- a/tide/core/data/FFMPEGFrame.cpp
+++ b/tide/core/data/FFMPEGFrame.cpp
@@ -67,11 +67,6 @@ int FFMPEGFrame::getHeight() const
     return _avFrame->height;
 }
 
-const uint8_t* FFMPEGFrame::getData( const uint texture ) const
-{
-    return _avFrame->data[texture];
-}
-
 int64_t FFMPEGFrame::getTimestamp() const
 {
     return _avFrame->pkt_dts;

--- a/tide/core/data/FFMPEGFrame.cpp
+++ b/tide/core/data/FFMPEGFrame.cpp
@@ -82,7 +82,7 @@ const AVFrame& FFMPEGFrame::getAVFrame() const
     return *_avFrame;
 }
 
-AVPixelFormat FFMPEGFrame::getAvPixelFormat() const
+AVPixelFormat FFMPEGFrame::getAVPixelFormat() const
 {
     return AVPixelFormat(_avFrame->format);
 }

--- a/tide/core/data/FFMPEGFrame.h
+++ b/tide/core/data/FFMPEGFrame.h
@@ -58,10 +58,10 @@ public:
     /** Destructor. */
     ~FFMPEGFrame();
 
-    /** @return the width of the image. */
+    /** @return the width of the frame. */
     int getWidth() const;
 
-    /** @return the height of the image. */
+    /** @return the height of the frame. */
     int getHeight() const;
 
     /** @return the timestamp of the frame. */
@@ -72,7 +72,7 @@ public:
     const AVFrame& getAVFrame() const;
 
     /** @return the pixel format of the FFMPEG frame. */
-    AVPixelFormat getAvPixelFormat() const;
+    AVPixelFormat getAVPixelFormat() const;
 
 private:
     AVFrame* _avFrame;

--- a/tide/core/data/FFMPEGFrame.h
+++ b/tide/core/data/FFMPEGFrame.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -59,10 +59,8 @@ extern "C"
     #include <libavutil/mem.h>
 }
 
-#include "Image.h"
-
 /** A frame of an FFMPEG movie. */
-class FFMPEGFrame : public Image
+class FFMPEGFrame
 {
 public:
     /** Constructor. */
@@ -71,27 +69,27 @@ public:
     /** Destructor. */
     ~FFMPEGFrame();
 
-    /** @return the timestamp of the frame. */
-    int64_t getTimestamp() const;
-
-    /** @copydoc Image::getData */
-    const uint8_t* getData() const override;
-
-    /** @copydoc Image::getFormat */
-    uint getFormat() const override;
-
     /** @copydoc Image::getWidth */
-    int getWidth() const override;
+    int getWidth() const;
 
     /** @copydoc Image::getHeight */
-    int getHeight() const override;
+    int getHeight() const;
+
+    /** @copydoc Image::getData */
+    const uint8_t* getData( uint texture = 0 ) const;
+
+    /** @return the timestamp of the frame. */
+    int64_t getTimestamp() const;
 
     /** Get the FFMPEG frame. */
     AVFrame& getAVFrame();
     const AVFrame& getAVFrame() const;
 
-protected:
+    /** @return the pixel format of the FFMPEG frame. */
+    AVPixelFormat getAvPixelFormat() const;
+
+private:
     AVFrame* _avFrame;
 };
 
-#endif // FFMPEGFRAME_H
+#endif

--- a/tide/core/data/FFMPEGMovie.cpp
+++ b/tide/core/data/FFMPEGMovie.cpp
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2014, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2014-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -46,10 +46,12 @@
 
 #include <cmath>
 
-#define MIN_SEEK_DELTA_SEC  0.5
-
 #pragma clang diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+namespace
+{
+const double MIN_SEEK_DELTA_SEC = 0.5;
 
 // Solve FFMPEG issue "insufficient thread locking around avcodec_open/close()"
 int ffmpegLockManagerCallback( void** mutex, enum AVLockOp op )
@@ -84,11 +86,10 @@ struct FFMPEGStaticInit
     }
 };
 static FFMPEGStaticInit instance;
+}
 
 FFMPEGMovie::FFMPEGMovie( const QString& uri )
-    : _avFormatContext( 0 )
-    , _streamPosition( 0.0 )
-    , _isValid( _open( uri ))
+    : _isValid( _open( uri ))
 {}
 
 FFMPEGMovie::~FFMPEGMovie()
@@ -105,6 +106,7 @@ bool FFMPEGMovie::_open( const QString& uri )
     try
     {
         _videoStream.reset( new FFMPEGVideoStream( *_avFormatContext ));
+        _format = _determineOutputFormat( _videoStream->getAvFormat(), uri );
     }
     catch( const std::runtime_error& e )
     {
@@ -178,6 +180,16 @@ double FFMPEGMovie::getFrameDuration() const
     return _videoStream->getFrameDuration();
 }
 
+TextureFormat FFMPEGMovie::getFormat() const
+{
+    return _format;
+}
+
+void FFMPEGMovie::setFormat( const TextureFormat format )
+{
+    _format = format;
+}
+
 PicturePtr FFMPEGMovie::getFrame( double posInSeconds )
 {
     posInSeconds = std::max( 0.0, std::min( posInSeconds, getDuration( )));
@@ -205,7 +217,7 @@ PicturePtr FFMPEGMovie::getFrame( double posInSeconds )
         const int64_t timestamp = _videoStream->decodeTimestamp( packet );
         if( timestamp >= targetTimestamp )
         {
-            picture = _videoStream->decodePictureForLastPacket();
+            picture = _videoStream->decodePictureForLastPacket( _format );
             // This validity check is to prevent against rare decoding errors
             // and is not inherently part of the seeking process.
             if( picture )
@@ -226,4 +238,29 @@ PicturePtr FFMPEGMovie::getFrame( double posInSeconds )
         picture = PicturePtr();
 
     return picture;
+}
+
+TextureFormat
+FFMPEGMovie::_determineOutputFormat( const AVPixelFormat fileFormat,
+                                     const QString& uri )
+{
+    switch( fileFormat )
+    {
+    case AV_PIX_FMT_RGBA:
+        return TextureFormat::rgba;
+    case AV_PIX_FMT_YUV420P:
+    case AV_PIX_FMT_YUVJ420P:
+        return TextureFormat::yuv420;
+    case AV_PIX_FMT_YUV422P:
+    case AV_PIX_FMT_YUVJ422P:
+        return TextureFormat::yuv422;
+    case AV_PIX_FMT_YUV444P:
+    case AV_PIX_FMT_YUVJ444P:
+        return TextureFormat::yuv444;
+    default:
+        put_flog( LOG_DEBUG, "Performance info: AV input format '%d' for file "
+                             "'%s' will be converted in software to 'rgba'",
+                  fileFormat, uri.toLocal8Bit().constData( ));
+        return TextureFormat::rgba;
+    }
 }

--- a/tide/core/data/FFMPEGMovie.h
+++ b/tide/core/data/FFMPEGMovie.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2014, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2014-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -98,6 +98,12 @@ public:
     /** Get the duration of a frame in seconds. */
     double getFrameDuration() const;
 
+    /** @return the format of the decoded movie frames. */
+    TextureFormat getFormat() const;
+
+    /** Set the format of the decoded movie frames, overwriting the default. */
+    void setFormat( TextureFormat format );
+
     /**
      * Get a frame at the given position in seconds.
      *
@@ -108,15 +114,18 @@ public:
     PicturePtr getFrame( double posInSeconds );
 
 private:
-    AVFormatContext* _avFormatContext;
-    std::unique_ptr< FFMPEGVideoStream > _videoStream;
+    AVFormatContext* _avFormatContext = nullptr;
+    std::unique_ptr<FFMPEGVideoStream> _videoStream;
+    TextureFormat _format = TextureFormat::yuv420;
 
-    double _streamPosition;
-    bool _isValid;
+    double _streamPosition = 0.0;
+    const bool _isValid = false;
 
     bool _open( const QString& uri );
     bool _createAvFormatContext( const QString& uri );
     void _releaseAvFormatContext();
+    TextureFormat _determineOutputFormat( AVPixelFormat fileFormat,
+                                          const QString& uri );
 };
 
-#endif // FFMPEGMOVIE_H
+#endif

--- a/tide/core/data/FFMPEGMovie.h
+++ b/tide/core/data/FFMPEGMovie.h
@@ -113,8 +113,6 @@ private:
     bool _open( const QString& uri );
     bool _createAvFormatContext( const QString& uri );
     void _releaseAvFormatContext();
-    TextureFormat _determineOutputFormat( AVPixelFormat fileFormat,
-                                          const QString& uri );
 };
 
 #endif

--- a/tide/core/data/FFMPEGMovie.h
+++ b/tide/core/data/FFMPEGMovie.h
@@ -40,18 +40,7 @@
 #ifndef FFMPEGMOVIE_H
 #define FFMPEGMOVIE_H
 
-// required for FFMPEG includes below, specifically for the Linux build
-#ifdef __cplusplus
-    #ifndef __STDC_CONSTANT_MACROS
-        #define __STDC_CONSTANT_MACROS
-    #endif
-
-    #ifdef _STDINT_H
-        #undef _STDINT_H
-    #endif
-
-    #include <stdint.h>
-#endif
+#include "FFMPEGDefines.h"
 
 extern "C"
 {

--- a/tide/core/data/FFMPEGPicture.cpp
+++ b/tide/core/data/FFMPEGPicture.cpp
@@ -56,20 +56,16 @@ FFMPEGPicture::FFMPEGPicture( const uint width, const uint height,
     switch( format )
     {
     case TextureFormat::rgba:
-        _dataSize[0] = width * height * 4;
-        _data[0].reset( new uint8_t[_dataSize[0]] );
+        _data[0] = QByteArray{ int(width * height * 4), Qt::Uninitialized };
         break;
     case TextureFormat::yuv420:
     case TextureFormat::yuv422:
     case TextureFormat::yuv444:
     {
-        const auto uvDataSize = _uvSize.width() * _uvSize.height();
-        _dataSize[0] = width * height;
-        _dataSize[1] = uvDataSize;
-        _dataSize[2] = uvDataSize;
-        _data[0].reset( new uint8_t[_dataSize[0]] );
-        _data[1].reset( new uint8_t[_dataSize[1]] );
-        _data[2].reset( new uint8_t[_dataSize[2]] );
+        const int uvDataSize = _uvSize.width() * _uvSize.height();
+        _data[0] = QByteArray{ int(width * height), Qt::Uninitialized };
+        _data[1] = QByteArray{ uvDataSize, Qt::Uninitialized };
+        _data[2] = QByteArray{ uvDataSize, Qt::Uninitialized };
         break;
     }
     default:
@@ -87,7 +83,7 @@ int FFMPEGPicture::getHeight() const
     return _height;
 }
 
-QSize FFMPEGPicture::getSize( const uint texture ) const
+QSize FFMPEGPicture::getTextureSize( const uint texture ) const
 {
     switch( texture )
     {
@@ -106,7 +102,7 @@ const uint8_t* FFMPEGPicture::getData( const uint texture ) const
     if( texture >= _data.size( ))
         return nullptr;
 
-    return _data[texture].get();
+    return reinterpret_cast<const uint8_t*>( _data[texture].constData( ));
 }
 
 uint8_t* FFMPEGPicture::getData( const uint texture )
@@ -114,15 +110,15 @@ uint8_t* FFMPEGPicture::getData( const uint texture )
     if( texture >= _data.size( ))
         return nullptr;
 
-    return _data[texture].get();
+    return reinterpret_cast<uint8_t*>( _data[texture].data( ));
 }
 
 size_t FFMPEGPicture::getDataSize( const uint texture ) const
 {
-    if( texture >= _dataSize.size( ))
+    if( texture >= _data.size( ))
         return 0;
 
-    return _dataSize[texture];
+    return _data[texture].size();
 }
 
 TextureFormat FFMPEGPicture::getFormat() const

--- a/tide/core/data/FFMPEGPicture.h
+++ b/tide/core/data/FFMPEGPicture.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -40,24 +40,56 @@
 #ifndef FFMPEGPICTURE_H
 #define FFMPEGPICTURE_H
 
-#include "FFMPEGFrame.h"
+#include "Image.h"
+
 #include <QImage>
 
+#include <array>
+
 /**
- * A decoded frame of the movie stream.
+ * A decoded frame of the movie stream in RGBA or YUV format.
  */
-class FFMPEGPicture : public FFMPEGFrame
+class FFMPEGPicture : public Image
 {
 public:
-    /** Constructor. */
-    FFMPEGPicture( unsigned int width, unsigned int height,
-                   AVPixelFormat format, int64_t timestamp );
+    /** Allocate a new picture. */
+    FFMPEGPicture( uint width, uint height, TextureFormat format );
 
-    /** Destructor. */
-    ~FFMPEGPicture();
+    /** @copydoc Image::getWidth */
+    int getWidth() const final;
 
-    /** Get the picture as a QImage. */
+    /** @copydoc Image::getHeight */
+    int getHeight() const final;
+
+    /** @copydoc Image::getData */
+    const uint8_t* getData( uint texture = 0 ) const final;
+
+    /** @return write access to fill a given image texture plane. */
+    uint8_t* getData( uint texture );
+
+    /** @return data size of a given image texture plane. */
+    size_t getDataSize( uint texture ) const;
+
+    /** @copydoc Image::getSize */
+    QSize getSize( uint texture = 0 ) const final;
+
+    /** @copydoc Image::getFormat */
+    TextureFormat getFormat() const final;
+
+    /** @copydoc Image::getGLPixelFormat */
+    uint getGLPixelFormat() const final;
+
+    /** @return the picture as a QImage, or an empty one if format != rgba. */
     QImage toQImage() const;
+
+private:
+    const uint _width;
+    const uint _height;
+    const TextureFormat _format;
+    const QSize _uvSize;
+    // std::vector are too slow because they can't allocate uninitialized memory
+    std::array<std::unique_ptr<uint8_t[]>, 3> _data;
+    std::array<size_t, 3> _dataSize = {{ 0, 0, 0 }};
 };
 
-#endif // FFMPEGPICTURE_H
+#endif

--- a/tide/core/data/FFMPEGPicture.h
+++ b/tide/core/data/FFMPEGPicture.h
@@ -42,6 +42,7 @@
 
 #include "Image.h"
 
+#include <QByteArray>
 #include <QImage>
 
 #include <array>
@@ -70,8 +71,8 @@ public:
     /** @return data size of a given image texture plane. */
     size_t getDataSize( uint texture ) const;
 
-    /** @copydoc Image::getSize */
-    QSize getSize( uint texture = 0 ) const final;
+    /** @copydoc Image::getTextureSize */
+    QSize getTextureSize( uint texture = 0 ) const final;
 
     /** @copydoc Image::getFormat */
     TextureFormat getFormat() const final;
@@ -87,9 +88,7 @@ private:
     const uint _height;
     const TextureFormat _format;
     const QSize _uvSize;
-    // std::vector are too slow because they can't allocate uninitialized memory
-    std::array<std::unique_ptr<uint8_t[]>, 3> _data;
-    std::array<size_t, 3> _dataSize = {{ 0, 0, 0 }};
+    std::array<QByteArray, 3> _data;
 };
 
 #endif

--- a/tide/core/data/FFMPEGVideoFrameConverter.cpp
+++ b/tide/core/data/FFMPEGVideoFrameConverter.cpp
@@ -45,18 +45,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-// required for FFMPEG includes below, specifically for the Linux build
-#ifdef __cplusplus
-    #ifndef __STDC_CONSTANT_MACROS
-        #define __STDC_CONSTANT_MACROS
-    #endif
-
-    #ifdef _STDINT_H
-        #undef _STDINT_H
-    #endif
-
-    #include <stdint.h>
-#endif
+#include "FFMPEGDefines.h"
 
 extern "C"
 {

--- a/tide/core/data/FFMPEGVideoFrameConverter.cpp
+++ b/tide/core/data/FFMPEGVideoFrameConverter.cpp
@@ -52,7 +52,7 @@ extern "C"
     #include <libswscale/swscale.h>
 }
 
-AVPixelFormat _toAvPixelFormat( const TextureFormat format )
+AVPixelFormat _toAVPixelFormat( const TextureFormat format )
 {
     switch( format )
     {
@@ -91,12 +91,12 @@ PicturePtr FFMPEGVideoFrameConverter::convert( const FFMPEGFrame& srcFrame,
                                                     srcFrame.getHeight(),
                                                     format );
 
-    const auto avFormat = _toAvPixelFormat( format );
+    const auto avFormat = _toAVPixelFormat( format );
 
     _impl->swsContext = sws_getCachedContext( _impl->swsContext,
                                               srcFrame.getWidth(),
                                               srcFrame.getHeight(),
-                                              srcFrame.getAvPixelFormat(),
+                                              srcFrame.getAVPixelFormat(),
                                               picture->getWidth(),
                                               picture->getHeight(),
                                               avFormat,
@@ -105,14 +105,14 @@ PicturePtr FFMPEGVideoFrameConverter::convert( const FFMPEGFrame& srcFrame,
     if( !_impl->swsContext )
         return PicturePtr();
 
-    uint8_t* dstData[4];
-    int linesize[4];
-    for( size_t i = 0; i < 4; ++i )
+    uint8_t* dstData[3];
+    int linesize[3];
+    for( size_t i = 0; i < 3; ++i )
     {
         dstData[i] = picture->getData( i );
         // width of image plane in pixels * bytes per pixel
         linesize[i] = picture->getDataSize( i ) /
-                      picture->getSize( i ).height();
+                      picture->getTextureSize( i ).height();
     }
 
     const auto outputHeight = sws_scale( _impl->swsContext,

--- a/tide/core/data/FFMPEGVideoFrameConverter.h
+++ b/tide/core/data/FFMPEGVideoFrameConverter.h
@@ -40,56 +40,31 @@
 #ifndef FFMPEGVIDEOFRAMECONVERTER_H
 #define FFMPEGVIDEOFRAMECONVERTER_H
 
-// required for FFMPEG includes below, specifically for the Linux build
-#ifdef __cplusplus
-    #ifndef __STDC_CONSTANT_MACROS
-        #define __STDC_CONSTANT_MACROS
-    #endif
-
-    #ifdef _STDINT_H
-        #undef _STDINT_H
-    #endif
-
-    #include <stdint.h>
-#endif
-
-extern "C"
-{
-    #include <libavutil/mem.h>
-    #include <libswscale/swscale.h>
-}
-
 #include "types.h"
-#include "FFMPEGFrame.h"
-#include "FFMPEGPicture.h"
 
 /**
- * Converts FFMPEG's AVFrame format to a data buffer of user-defined format
+ * Convert FFMPEG AVFrames to pictures in a user-defined format.
  */
 class FFMPEGVideoFrameConverter
 {
 public:
-    /**
-     * Create a new converter
-     * @param videoCodecContext The FFMPEG context to allocate resources
-     * @param targetFormat The desired data output format (e.g. PIX_FMT_RGBA)
-     * @throw std::runtime_error if an error occured during initialization
-     */
-    FFMPEGVideoFrameConverter( const AVCodecContext& videoCodecContext,
-                               AVPixelFormat targetFormat );
-    /** Desturctor */
+    /** Constructor. */
+    FFMPEGVideoFrameConverter();
+
+    /** Destroy the converter, freeing up resources. */
     ~FFMPEGVideoFrameConverter();
 
     /**
-     * Convert an AVFrame to the target data format
+     * Convert an AVFrame to the target format.
      * @param srcFrame The source frame
+     * @param format The desired data output format for the picture
      * @return The converted picture, or nullptr on error
      */
-    PicturePtr convert( const FFMPEGFrame& srcFrame );
+    PicturePtr convert( const FFMPEGFrame& srcFrame, TextureFormat format );
 
 private:
-    SwsContext* _swsContext;           // Scaling context
-    const AVPixelFormat _targetFormat;
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 #endif

--- a/tide/core/data/FFMPEGVideoStream.cpp
+++ b/tide/core/data/FFMPEGVideoStream.cpp
@@ -179,7 +179,7 @@ double FFMPEGVideoStream::getFrameDuration() const
     return _frameDurationInSeconds;
 }
 
-AVPixelFormat FFMPEGVideoStream::getAvFormat() const
+AVPixelFormat FFMPEGVideoStream::getAVFormat() const
 {
     return _videoCodecContext->pix_fmt;
 }

--- a/tide/core/data/FFMPEGVideoStream.cpp
+++ b/tide/core/data/FFMPEGVideoStream.cpp
@@ -39,8 +39,8 @@
 
 #include "FFMPEGVideoStream.h"
 
+#include "FFMPEGFrame.h"
 #include "FFMPEGVideoFrameConverter.h"
-
 #include "log.h"
 
 #include <sstream>
@@ -63,8 +63,7 @@ FFMPEGVideoStream::FFMPEGVideoStream( AVFormatContext& avFormatContext )
     _generateSeekingParameters();
 
     _frame.reset( new FFMPEGFrame );
-    _frameConverter.reset( new FFMPEGVideoFrameConverter( *_videoCodecContext,
-                                                          AV_PIX_FMT_RGBA ));
+    _frameConverter.reset( new FFMPEGVideoFrameConverter );
 }
 
 FFMPEGVideoStream::~FFMPEGVideoStream()
@@ -76,12 +75,13 @@ FFMPEGVideoStream::~FFMPEGVideoStream()
 #endif
 }
 
-PicturePtr FFMPEGVideoStream::decode( AVPacket& packet )
+PicturePtr
+FFMPEGVideoStream::decode( AVPacket& packet, const TextureFormat format )
 {
     if( !_decodeToAvFrame( packet ))
         return PicturePtr();
 
-    return decodePictureForLastPacket();
+    return decodePictureForLastPacket( format );
 }
 
 int64_t FFMPEGVideoStream::decodeTimestamp( AVPacket& packet )
@@ -92,9 +92,10 @@ int64_t FFMPEGVideoStream::decodeTimestamp( AVPacket& packet )
     return _frame->getTimestamp();
 }
 
-PicturePtr FFMPEGVideoStream::decodePictureForLastPacket()
+PicturePtr
+FFMPEGVideoStream::decodePictureForLastPacket( const TextureFormat format )
 {
-    return _frameConverter->convert( *_frame );
+    return _frameConverter->convert( *_frame, format );
 }
 
 bool FFMPEGVideoStream::_isVideoPacket( const AVPacket& packet ) const
@@ -176,6 +177,11 @@ double FFMPEGVideoStream::getDuration() const
 double FFMPEGVideoStream::getFrameDuration() const
 {
     return _frameDurationInSeconds;
+}
+
+AVPixelFormat FFMPEGVideoStream::getAvFormat() const
+{
+    return _videoCodecContext->pix_fmt;
 }
 
 int64_t FFMPEGVideoStream::getFrameIndex( const double timePositionInSec ) const
@@ -298,6 +304,9 @@ void FFMPEGVideoStream::_openVideoStreamDecoder()
                    _getAvError( ret );
         throw std::runtime_error( message.str( ));
     }
+
+    if( _videoCodecContext->pix_fmt == AV_PIX_FMT_NONE )
+        throw std::runtime_error( "video stream has undefined pixel format" );
 }
 
 void FFMPEGVideoStream::_generateSeekingParameters()

--- a/tide/core/data/FFMPEGVideoStream.h
+++ b/tide/core/data/FFMPEGVideoStream.h
@@ -40,18 +40,7 @@
 #ifndef FFMPEGVIDEOSTREAM_H
 #define FFMPEGVIDEOSTREAM_H
 
-// required for FFMPEG includes below, specifically for the Linux build
-#ifdef __cplusplus
-    #ifndef __STDC_CONSTANT_MACROS
-        #define __STDC_CONSTANT_MACROS
-    #endif
-
-    #ifdef _STDINT_H
-        #undef _STDINT_H
-    #endif
-
-    #include <stdint.h>
-#endif
+#include "FFMPEGDefines.h"
 
 extern "C"
 {

--- a/tide/core/data/FFMPEGVideoStream.h
+++ b/tide/core/data/FFMPEGVideoStream.h
@@ -114,7 +114,7 @@ public:
     double getFrameDuration() const;
 
     /** @return native format of the video stream. */
-    AVPixelFormat getAvFormat() const;
+    AVPixelFormat getAVFormat() const;
 
     /** Get the frameIndex corresponding to the given time in seconds. */
     int64_t getFrameIndex( double timePositionInSec ) const;

--- a/tide/core/data/FFMPEGVideoStream.h
+++ b/tide/core/data/FFMPEGVideoStream.h
@@ -81,10 +81,11 @@ public:
      * Decode a video packet.
      *
      * @param packet The av packet to decode
+     * @param format The format for the decoded picture.
      * @return The decoded picture, or nullptr if the input is not a video
      *         packet or an error occured.
      */
-    PicturePtr decode( AVPacket& packet );
+    PicturePtr decode( AVPacket& packet, TextureFormat format );
 
     /**
      * Partially decode a video packet to determine its timestamp.
@@ -103,9 +104,10 @@ public:
 
     /**
      * Call after a successful decodeTimestamp to get the corresponding picture.
+     * @param format The format for the decoded picture.
      * @return The decoded picture, or nullptr if an error occured.
      */
-    PicturePtr decodePictureForLastPacket();
+    PicturePtr decodePictureForLastPacket( TextureFormat format );
 
     /** Get the width of the video stream. */
     unsigned int getWidth() const;
@@ -121,6 +123,9 @@ public:
 
     /** Get the duration of a frame in seconds. */
     double getFrameDuration() const;
+
+    /** @return native format of the video stream. */
+    AVPixelFormat getAvFormat() const;
 
     /** Get the frameIndex corresponding to the given time in seconds. */
     int64_t getFrameIndex( double timePositionInSec ) const;

--- a/tide/core/data/Image.h
+++ b/tide/core/data/Image.h
@@ -1,6 +1,7 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Daniel.Nachbaur@epfl.ch                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -46,8 +47,11 @@
  * An interface to provide necessary image information for the texture upload
  * and swap in TextureUploader.
  *
- * Currently, the only valid image format is 32 bits per pixel. Derived
- * classes must make sure to comply with this requirement.
+ * Valid image formats are:
+ * - RGBA: 1 texture plane, 32 bits per pixel (in any GL-compatible arrangement)
+ * - YUV: 3 texture planes, 8 bits per pixel
+ *
+ * Derived classes must comply with this requirement.
  */
 class Image
 {
@@ -60,14 +64,20 @@ public:
     /** @return the height of the image. */
     virtual int getHeight() const = 0;
 
-    /** @return the size of the image in bytes */
-    size_t getSize() const { return getWidth() * getHeight() * 4; }
+    /** @return the dimensions of the given texture plane. */
+    virtual QSize getSize( uint texture = 0 ) const
+    {
+        return texture == 0 ? QSize( getWidth(), getHeight( )) : QSize();
+    }
 
-    /** @return the pointer to the pixels. */
-    virtual const uint8_t* getData() const = 0;
+    /** @return the pointer to the pixels of the given texture plane. */
+    virtual const uint8_t* getData( uint texture = 0 ) const = 0;
+
+    /** @return the format of the image. */
+    virtual TextureFormat getFormat() const = 0;
 
     /** @return the OpenGL pixel format of the image data. */
-    virtual uint getFormat() const = 0;
+    virtual uint getGLPixelFormat() const = 0;
 
     /** @return true if the image is a GPU image and need special processing. */
     virtual bool isGpuImage() const { return false; }

--- a/tide/core/data/Image.h
+++ b/tide/core/data/Image.h
@@ -65,7 +65,7 @@ public:
     virtual int getHeight() const = 0;
 
     /** @return the dimensions of the given texture plane. */
-    virtual QSize getSize( uint texture = 0 ) const
+    virtual QSize getTextureSize( uint texture = 0 ) const
     {
         return texture == 0 ? QSize( getWidth(), getHeight( )) : QSize();
     }

--- a/tide/core/data/QtImage.cpp
+++ b/tide/core/data/QtImage.cpp
@@ -58,12 +58,18 @@ int QtImage::getHeight() const
     return _image.height();
 }
 
-const uint8_t* QtImage::getData() const
+const uint8_t* QtImage::getData( const uint texture ) const
 {
+    Q_UNUSED( texture );
     return _image.constBits();
 }
 
-uint QtImage::getFormat() const
+TextureFormat QtImage::getFormat() const
+{
+    return TextureFormat::rgba;
+}
+
+uint QtImage::getGLPixelFormat() const
 {
     return GL_BGRA;
 }

--- a/tide/core/data/QtImage.h
+++ b/tide/core/data/QtImage.h
@@ -65,10 +65,13 @@ public:
     int getHeight() const override;
 
     /** @copydoc Image::getData */
-    const uint8_t* getData() const override;
+    const uint8_t* getData( uint texture = 0 ) const override;
 
     /** @copydoc Image::getFormat */
-    uint getFormat() const override;
+    TextureFormat getFormat() const override;
+
+    /** @copydoc Image::getGLPixelFormat */
+    uint getGLPixelFormat() const override;
 
     /** @return true if the image format is 32 bits per pixel. */
     static bool is32Bits( const QImage& image )
@@ -80,4 +83,4 @@ private:
     const QImage _image;
 };
 
-#endif // QTIMAGE_H
+#endif

--- a/tide/core/thumbnail/MovieThumbnailGenerator.cpp
+++ b/tide/core/thumbnail/MovieThumbnailGenerator.cpp
@@ -52,13 +52,13 @@ MovieThumbnailGenerator::MovieThumbnailGenerator( const QSize& size )
 QImage MovieThumbnailGenerator::generate( const QString& filename ) const
 {
     FFMPEGMovie movie( filename );
+    movie.setFormat( TextureFormat::rgba );
 
     if( !movie.isValid( ))
         return createErrorImage( "movie" );
 
     const double target = PREVIEW_RELATIVE_POSITION * movie.getDuration();
-    PicturePtr picture = movie.getFrame( target );
-    if( picture )
+    if( auto picture = movie.getFrame( target ))
         return picture->toQImage().scaled( _size, _aspectRatioMode );
 
     return createErrorImage( "movie" );

--- a/tide/core/types.h
+++ b/tide/core/types.h
@@ -51,6 +51,17 @@
 #include <set>
 #include <vector>
 
+/**
+ * The type of texture formats that Tide can render.
+ */
+enum class TextureFormat
+{
+    rgba,
+    yuv420,
+    yuv422,
+    yuv444
+};
+
 class Configuration;
 class Content;
 class ContentSynchronizer;

--- a/tide/core/yuv.cpp
+++ b/tide/core/yuv.cpp
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,47 +37,25 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#include "SVGGpuImage.h"
+#include "yuv.h"
 
-SVGGpuImage::SVGGpuImage( const SVGTiler& dataSource, const uint tileId )
-    : _dataSource( dataSource )
-    , _tileId( tileId )
-{}
-
-int SVGGpuImage::getWidth() const
+namespace yuv
 {
-    return _image->getWidth();
+
+QSize getUVSize( const QSize& ySize, const TextureFormat format )
+{
+    switch( format )
+    {
+    case TextureFormat::yuv444:
+        return ySize;
+    case TextureFormat::yuv422:
+        return { ySize.width() >> 1, ySize.height() };
+    case TextureFormat::yuv420:
+        return ySize / 2;
+    case TextureFormat::rgba:
+    default:
+        return QSize();
+    }
 }
 
-int SVGGpuImage::getHeight() const
-{
-    return _image->getHeight();
-}
-
-const uint8_t* SVGGpuImage::getData( const uint texture ) const
-{
-    Q_UNUSED( texture );
-    return _image->getData();
-}
-
-TextureFormat SVGGpuImage::getFormat() const
-{
-    return TextureFormat::rgba;
-}
-
-uint SVGGpuImage::getGLPixelFormat() const
-{
-    return _image->getGLPixelFormat();
-}
-
-bool SVGGpuImage::isGpuImage() const
-{
-    return true;
-}
-
-bool SVGGpuImage::generateGpuImage()
-{
-    // Call getTileImage so that the image gets cached for the next request
-    _image = _dataSource.getTileImage( _tileId );
-    return true;
 }

--- a/tide/core/yuv.h
+++ b/tide/core/yuv.h
@@ -49,7 +49,7 @@ namespace yuv
 {
 
 /** @return the U and V texture size for a given Y size and format. */
-QSize getUVSize( const QSize& ySize, const TextureFormat format );
+QSize getUVSize( const QSize& ySize, TextureFormat format );
 
 }
 

--- a/tide/core/yuv.h
+++ b/tide/core/yuv.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,47 +37,20 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#include "SVGGpuImage.h"
+#ifndef YUV_H
+#define YUV_H
 
-SVGGpuImage::SVGGpuImage( const SVGTiler& dataSource, const uint tileId )
-    : _dataSource( dataSource )
-    , _tileId( tileId )
-{}
+#include "types.h"
 
-int SVGGpuImage::getWidth() const
+/**
+ * Helper functions for yuv textures.
+ */
+namespace yuv
 {
-    return _image->getWidth();
+
+/** @return the U and V texture size for a given Y size and format. */
+QSize getUVSize( const QSize& ySize, const TextureFormat format );
+
 }
 
-int SVGGpuImage::getHeight() const
-{
-    return _image->getHeight();
-}
-
-const uint8_t* SVGGpuImage::getData( const uint texture ) const
-{
-    Q_UNUSED( texture );
-    return _image->getData();
-}
-
-TextureFormat SVGGpuImage::getFormat() const
-{
-    return TextureFormat::rgba;
-}
-
-uint SVGGpuImage::getGLPixelFormat() const
-{
-    return _image->getGLPixelFormat();
-}
-
-bool SVGGpuImage::isGpuImage() const
-{
-    return true;
-}
-
-bool SVGGpuImage::generateGpuImage()
-{
-    // Call getTileImage so that the image gets cached for the next request
-    _image = _dataSource.getTileImage( _tileId );
-    return true;
-}
+#endif

--- a/tide/wall/CMakeLists.txt
+++ b/tide/wall/CMakeLists.txt
@@ -72,6 +72,7 @@ list(APPEND TIDEWALL_PUBLIC_HEADERS
   SVGTiler.h
   TestPattern.h
   TextureNode.h
+  TextureNodeYUV.h
   TextureUploader.h
   TiledSynchronizer.h
   Tile.h
@@ -79,6 +80,7 @@ list(APPEND TIDEWALL_PUBLIC_HEADERS
   WallApplication.h
   WallConfiguration.h
   WallWindow.h
+  YUVTexture.h
 )
 
 list(APPEND TIDEWALL_SOURCES
@@ -108,6 +110,7 @@ list(APPEND TIDEWALL_SOURCES
   SVGTiler.cpp
   TestPattern.cpp
   TextureNode.cpp
+  TextureNodeYUV.cpp
   TextureUploader.cpp
   Tile.cpp
   TiledSynchronizer.cpp

--- a/tide/wall/MovieSynchronizer.cpp
+++ b/tide/wall/MovieSynchronizer.cpp
@@ -64,7 +64,8 @@ void MovieSynchronizer::update( const ContentWindow& window,
     if( !_tileAdded )
     {
         emit addTile( std::make_shared<Tile>( 0, QRect( QPoint( 0, 0 ),
-                                                        getTilesArea( ))));
+                                                        getTilesArea( )),
+                                              _updater->getFormat( )));
         emit tilesAreaChanged();
         _tileAdded = true;
     }

--- a/tide/wall/MovieUpdater.cpp
+++ b/tide/wall/MovieUpdater.cpp
@@ -162,6 +162,11 @@ qreal MovieUpdater::getSkipPosition() const
     return _skipPosition / _ffmpegMovie->getDuration();
 }
 
+TextureFormat MovieUpdater::getFormat() const
+{
+    return _ffmpegMovie->getFormat();
+}
+
 bool MovieUpdater::advanceToNextFrame( WallToWallChannel& channel )
 {
     const double frameDuration = _ffmpegMovie->getFrameDuration();

--- a/tide/wall/MovieUpdater.h
+++ b/tide/wall/MovieUpdater.h
@@ -108,6 +108,9 @@ public:
     /** @return skip position of the movie, normalized between [0.0, 1.0]. */
     qreal getSkipPosition() const;
 
+    /** @return the format of the decoded movie images. */
+    TextureFormat getFormat() const;
+
 private:
     std::unique_ptr<FFMPEGMovie> _ffmpegMovie;
     FpsCounter _fpsCounter;

--- a/tide/wall/SVGGpuImage.h
+++ b/tide/wall/SVGGpuImage.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -63,10 +63,13 @@ public:
     int getHeight() const override;
 
     /** @copydoc Image::getData */
-    const uint8_t* getData() const override;
+    const uint8_t* getData( uint texture = 0 ) const override;
 
     /** @copydoc Image::getFormat */
-    uint getFormat() const override;
+    TextureFormat getFormat() const override;
+
+    /** @copydoc Image::getGLPixelFormat */
+    uint getGLPixelFormat() const override;
 
     /** @copydoc Image::isGpuImage */
     bool isGpuImage() const final;

--- a/tide/wall/StreamImage.cpp
+++ b/tide/wall/StreamImage.cpp
@@ -1,6 +1,7 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Daniel.Nachbaur@epfl.ch                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -57,13 +58,19 @@ int StreamImage::getHeight() const
     return _frame->segments.at( _tileIndex ).parameters.height;
 }
 
-const uint8_t* StreamImage::getData() const
+const uint8_t* StreamImage::getData( const uint texture ) const
 {
-    return reinterpret_cast< const uint8_t* >(
+    Q_UNUSED( texture );
+    return reinterpret_cast<const uint8_t*>(
                 _frame->segments.at( _tileIndex ).imageData.constData( ));
 }
 
-uint StreamImage::getFormat() const
+TextureFormat StreamImage::getFormat() const
+{
+    return TextureFormat::rgba;
+}
+
+uint StreamImage::getGLPixelFormat() const
 {
     return GL_RGBA;
 }

--- a/tide/wall/StreamImage.h
+++ b/tide/wall/StreamImage.h
@@ -1,6 +1,7 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Daniel.Nachbaur@epfl.ch                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -60,10 +61,13 @@ public:
     int getHeight() const override;
 
     /** @copydoc Image::getData */
-    const uint8_t* getData() const override;
+    const uint8_t* getData( uint texture ) const override;
 
     /** @copydoc Image::getFormat */
-    uint getFormat() const override;
+    TextureFormat getFormat() const override;
+
+    /** @copydoc Image::getGLPixelFormat */
+    uint getGLPixelFormat() const override;
 
 private:
     deflect::FramePtr _frame;

--- a/tide/wall/TextureNode.cpp
+++ b/tide/wall/TextureNode.cpp
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -43,7 +43,8 @@
 #include <QOpenGLFunctions>
 #include <QQuickWindow>
 
-TextureNode::TextureNode( const QSize& size, QQuickWindow* window )
+TextureNode::TextureNode( const QSize& size, QQuickWindow* window,
+                          TextureFormat )
     : _window( window )
     , _frontTexture( window->createTextureFromId( 0 , QSize( 1 ,1 )))
     , _backTexture( _createTexture( size ))
@@ -53,13 +54,13 @@ TextureNode::TextureNode( const QSize& size, QQuickWindow* window )
     setMipmapFiltering( QSGTexture::Linear );
 }
 
-void TextureNode::setMipmapFiltering( const QSGTexture::Filtering mipmapFiltering )
+void TextureNode::setMipmapFiltering( const QSGTexture::Filtering filtering )
 {
-    auto mat = static_cast< QSGOpaqueTextureMaterial* >( material( ));
-    auto opaqueMat = static_cast< QSGOpaqueTextureMaterial* >( opaqueMaterial( ));
+    auto mat = static_cast<QSGOpaqueTextureMaterial*>( material( ));
+    auto opaqueMat = static_cast<QSGOpaqueTextureMaterial*>( opaqueMaterial( ));
 
-    mat->setMipmapFiltering( mipmapFiltering );
-    opaqueMat->setMipmapFiltering( mipmapFiltering );
+    mat->setMipmapFiltering( filtering );
+    opaqueMat->setMipmapFiltering( filtering );
 }
 
 uint TextureNode::getBackGlTexture() const

--- a/tide/wall/TextureNode.h
+++ b/tide/wall/TextureNode.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -40,6 +40,8 @@
 #ifndef TEXTURENODE_H
 #define TEXTURENODE_H
 
+#include "types.h"
+
 #include <QSGSimpleTextureNode>
 #include <memory>
 
@@ -59,7 +61,14 @@ class QQuickWindow;
 class TextureNode : public QSGSimpleTextureNode
 {
 public:
-    TextureNode( const QSize& size, QQuickWindow* window );
+    /**
+     * Create a textured rectangle for rendering YUV images on the GPU.
+     * @param size the initial back texture size.
+     * @param window a reference to the quick window for generating textures.
+     * @param format ignored, needed for symmetry with TextureNodeYUV API.
+     */
+    TextureNode( const QSize& size, QQuickWindow* window,
+                 TextureFormat format = TextureFormat::rgba );
 
     /** @return the back texture identifier, which can safely be updated. */
     uint getBackGlTexture() const;
@@ -76,7 +85,7 @@ public:
     void setBackTextureSize( const QSize& size );
 
     /** @sa QSGOpaqueTextureMaterial::setMipmapFiltering */
-    void setMipmapFiltering( const QSGTexture::Filtering mipmapFiltering );
+    void setMipmapFiltering( const QSGTexture::Filtering filtering );
 
 private:
     QQuickWindow* _window;
@@ -86,7 +95,7 @@ private:
     QSGTexturePtr _backTexture;
 
     QSGTexturePtr _createTexture( const QSize& size ) const;
-    QSGTexturePtr _createWrapper( const uint textureID, const QSize& size ) const;
+    QSGTexturePtr _createWrapper( uint textureID, const QSize& size ) const;
 };
 
 #endif

--- a/tide/wall/TextureNodeYUV.cpp
+++ b/tide/wall/TextureNodeYUV.cpp
@@ -1,0 +1,264 @@
+/*********************************************************************/
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of Ecole polytechnique federale de Lausanne.          */
+/*********************************************************************/
+
+#include "TextureNodeYUV.h"
+
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
+#include <QQuickWindow>
+#include <QSGSimpleMaterialShader>
+
+namespace
+{
+
+const char* vertShader =
+R"(
+#version 130
+uniform highp mat4 qt_Matrix;
+attribute highp vec4 aVertex;
+attribute highp vec2 aTexCoord;
+out vec2 vTexCoord;
+void main() {
+    gl_Position = qt_Matrix * aVertex;
+    vTexCoord = aTexCoord;
+}
+)";
+
+const char* fragShader =
+R"(
+#version 130
+uniform lowp float qt_Opacity;
+uniform lowp sampler2D y_tex;
+uniform lowp sampler2D u_tex;
+uniform lowp sampler2D v_tex;
+in vec2 vTexCoord;
+const vec3 offset = vec3(-0.0625, -0.5, -0.5);
+const vec3 R_cf = vec3(1.164383,  0.000000,  1.596027);
+const vec3 G_cf = vec3(1.164383, -0.391762, -0.812968);
+const vec3 B_cf = vec3(1.164383,  2.017232,  0.000000);
+void main() {
+  float y = texture2D(y_tex, vTexCoord).r;
+  float u = texture2D(u_tex, vTexCoord).r;
+  float v = texture2D(v_tex, vTexCoord).r;
+  vec3 yuv = vec3(y, u, v);
+  yuv += offset;
+  float r = dot(yuv, R_cf);
+  float g = dot(yuv, G_cf);
+  float b = dot(yuv, B_cf);
+  gl_FragColor = vec4(r, g, b, qt_Opacity);
+}
+)";
+
+}
+
+/**
+ * The state of the QSGSimpleMaterialShader.
+ */
+struct YUVState
+{
+    std::unique_ptr<QSGTexture> frontY;
+    std::unique_ptr<QSGTexture> frontU;
+    std::unique_ptr<QSGTexture> frontV;
+
+    std::unique_ptr<QSGTexture> backY;
+    std::unique_ptr<QSGTexture> backU;
+    std::unique_ptr<QSGTexture> backV;
+};
+
+/**
+ * Material to render a YUV texture with OpenGL in a QSGNode.
+ */
+class YUVShader : public QSGSimpleMaterialShader<YUVState>
+{
+    QSG_DECLARE_SIMPLE_SHADER(YUVShader, YUVState)
+
+public:
+    QList<QByteArray> attributes() const final
+    {
+        return QList<QByteArray>() << "aVertex" << "aTexCoord";
+    }
+
+    const char* vertexShader() const final { return vertShader; }
+    const char* fragmentShader() const final { return fragShader; }
+
+    void updateState( const YUVState* newState, const YUVState* ) final
+    {
+        auto gl = QOpenGLContext::currentContext()->functions();
+        // We bind the textures in inverse order so that we leave the
+        // updateState function with GL_TEXTURE0 as the active texture unit.
+        // This is maintain the "contract" that updateState should not mess up
+        // the GL state beyond what is needed for this material.
+        gl->glActiveTexture( GL_TEXTURE2 );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                             GL_LINEAR_MIPMAP_LINEAR );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                             GL_LINEAR );
+        newState->frontV->bind();
+
+        gl->glActiveTexture( GL_TEXTURE1 );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                             GL_LINEAR_MIPMAP_LINEAR );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                             GL_LINEAR );
+        newState->frontU->bind();
+
+        gl->glActiveTexture( GL_TEXTURE0 );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                             GL_LINEAR_MIPMAP_LINEAR );
+        gl->glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                             GL_LINEAR );
+        newState->frontY->bind();
+    }
+
+    void resolveUniforms() final
+    {
+        program()->setUniformValue( "y_tex", 0 ); // GL_TEXTURE0
+        program()->setUniformValue( "u_tex", 1 ); // GL_TEXTURE1
+        program()->setUniformValue( "v_tex", 2 ); // GL_TEXTURE2
+    }
+};
+
+YUVState* _getMaterialState( QSGGeometryNode& node )
+{
+    using YUVShaderMaterial = QSGSimpleMaterial<YUVState>;
+    return static_cast<YUVShaderMaterial*>( node.material( ))->state();
+}
+
+const YUVState* _getMaterialState( const QSGGeometryNode& node )
+{
+    using YUVShaderMaterial = QSGSimpleMaterial<YUVState>;
+    return static_cast<const YUVShaderMaterial*>( node.material( ))->state();
+}
+
+TextureNodeYUV::TextureNodeYUV( const QSize& size, QQuickWindow* window,
+                                const TextureFormat format )
+    : _window( window )
+    , _format( format )
+{
+    // Set up geometry, actual vertices will be initialized in updatePaintNode
+    const auto& attr = QSGGeometry::defaultAttributes_TexturedPoint2D();
+    _node.setGeometry( new QSGGeometry( attr, 4 ));
+    _node.setFlag( QSGNode::OwnsGeometry );
+
+    _node.setMaterial( YUVShader::createMaterial( ));
+    _node.setFlag( QSGNode::OwnsMaterial );
+
+    auto state = _getMaterialState( _node );
+    state->frontY.reset( _window->createTextureFromId( 0, QSize( 1, 1 )));
+    state->frontU.reset( _window->createTextureFromId( 0, QSize( 1, 1 )));
+    state->frontV.reset( _window->createTextureFromId( 0, QSize( 1, 1 )));
+
+    _createBackTextures( size );
+    appendChildNode( &_node );
+}
+
+const QRectF& TextureNodeYUV::rect() const
+{
+    return _rect;
+}
+
+void TextureNodeYUV::setRect( const QRectF& rect )
+{
+    if( _rect == rect )
+        return;
+
+    _rect = rect;
+    QSGGeometry::updateTexturedRectGeometry( _node.geometry(), _rect,
+                                             UNIT_RECTF );
+    _node.markDirty( QSGNode::DirtyGeometry );
+}
+
+YUVTexture TextureNodeYUV::getBackGlTexture() const
+{
+    const auto state = _getMaterialState( _node );
+
+    return YUVTexture{ state->backY->textureId(), state->backU->textureId(),
+                       state->backV->textureId() };
+}
+
+void TextureNodeYUV::swap()
+{
+    auto state = _getMaterialState( _node );
+
+    std::swap( state->frontY, state->backY );
+    std::swap( state->frontU, state->backU );
+    std::swap( state->frontV, state->backV );
+
+    markDirty( DirtyMaterial );
+}
+
+void TextureNodeYUV::setBackTextureSize( const QSize& size )
+{
+    auto state = _getMaterialState( _node );
+    if( state->backY->textureSize() == size )
+        return;
+
+    _createBackTextures( size );
+}
+
+void TextureNodeYUV::_createBackTextures( const QSize& size )
+{
+    const auto uvSize = yuv::getUVSize( size, _format );
+    auto state = _getMaterialState( _node );
+
+    state->backY = _createTexture( size );
+    state->backU = _createTexture( uvSize );
+    state->backV = _createTexture( uvSize );
+}
+
+TextureNodeYUV::QSGTexturePtr
+TextureNodeYUV::_createTexture( const QSize& size ) const
+{
+    uint textureID = 0;
+    auto gl = QOpenGLContext::currentContext()->functions();
+    gl->glGenTextures( 1, &textureID );
+    gl->glBindTexture( GL_TEXTURE_2D, textureID );
+    gl->glTexImage2D( GL_TEXTURE_2D, 0, GL_R8, size.width(), size.height(), 0,
+                      GL_RED, GL_UNSIGNED_BYTE, nullptr );
+    return _createWrapper( textureID, size );
+}
+
+TextureNodeYUV::QSGTexturePtr
+TextureNodeYUV::_createWrapper( const uint textureID, const QSize& size ) const
+{
+    const auto textureFlags = QQuickWindow::CreateTextureOptions(
+                                  QQuickWindow::TextureOwnsGLTexture );
+    return QSGTexturePtr( _window->createTextureFromId( textureID, size,
+                                                        textureFlags ));
+}

--- a/tide/wall/TextureNodeYUV.h
+++ b/tide/wall/TextureNodeYUV.h
@@ -60,10 +60,8 @@ class QQuickWindow;
  * that no memory is wasted for a second texture if the node is not going to
  * be updated more than once.
  */
-class TextureNodeYUV : public QObject, public QSGNode
+class TextureNodeYUV : public QSGNode
 {
-    Q_OBJECT
-
 public:
     /**
      * Create a textured rectangle for rendering YUV images on the GPU.

--- a/tide/wall/TextureUploader.cpp
+++ b/tide/wall/TextureUploader.cpp
@@ -183,7 +183,7 @@ bool TextureUploader::_upload( const Image& image, const Tile& tile )
 void TextureUploader::_upload( const Image& image, const uint srcTextureIdx,
                                const uint textureID )
 {
-    const auto textureSize = image.getSize( srcTextureIdx );
+    const auto textureSize = image.getTextureSize( srcTextureIdx );
 
     GLint alignment = 1;
     if( (textureSize.width() % 4) == 0 )

--- a/tide/wall/TextureUploader.cpp
+++ b/tide/wall/TextureUploader.cpp
@@ -124,18 +124,18 @@ void TextureUploader::uploadTexture( ImagePtr image, TileWeakPtr tile_ )
     if( image->getWidth() != tile->getBackGlTextureSize().width() ||
         image->getHeight() != tile->getBackGlTextureSize().height( ))
     {
-        put_flog( LOG_DEBUG, "Incompatible image dimensions!" );
+        put_flog( LOG_DEBUG, "Incompatible image dimensions" );
         return;
     }
 
-    const uint textureID = tile->getBackGlTexture();
-    if( !textureID )
+    if( image->getFormat() != tile->getFormat( ))
     {
-        put_flog( LOG_DEBUG, "Tile has no backTextureID" );
+        put_flog( LOG_DEBUG, "Incompatible texture formats" );
         return;
     }
 
-    _upload( *image, textureID );
+    if( !_upload( *image, *tile ))
+        return;
 
     // notify tile that its texture has been updated
     tile->textureUpdated( tile );
@@ -144,60 +144,58 @@ void TextureUploader::uploadTexture( ImagePtr image, TileWeakPtr tile_ )
     emit uploaded();
 }
 
-void TextureUploader::_upload( const Image& image, const uint textureID )
+bool TextureUploader::_upload( const Image& image, const Tile& tile )
 {
-    // we observed slow-downs with movie session and pixelstreams together
-    // which originates from glFinish() in upload & render thread. For now
-    // we use 'slow&easy' texture upload. This probably points out the problem
-    // and a potential solution:
-    // http://stackoverflow.com/questions/31941385
-#if 0
-    // make PBO big enough
-    _gl->glBindBuffer( GL_PIXEL_UNPACK_BUFFER, _pbo );
-    const size_t bufferSize = image.getSize();
-    if( bufferSize > _bufferSize )
+    switch( image.getFormat( ))
     {
-        _gl->glBufferData( GL_PIXEL_UNPACK_BUFFER, bufferSize, 0,
-                           GL_STREAM_DRAW );
-        _bufferSize = bufferSize;
+    case TextureFormat::rgba:
+    {
+        const auto textureID = tile.getBackGlTexture();
+        if( !textureID )
+        {
+            put_flog( LOG_DEBUG, "Tile has no backTextureID" );
+            return false;
+        }
+        _upload( image, 0, textureID );
+        return true;
     }
+    case TextureFormat::yuv444:
+    case TextureFormat::yuv422:
+    case TextureFormat::yuv420:
+    {
+        const auto& texture = tile.getBackGlTextureYUV();
+        if( !texture.y || !texture.u || !texture.v )
+        {
+            put_flog( LOG_DEBUG, "Tile is missing a back GL texture" );
+            return false;
+        }
+        _upload( image, 0, texture.y );
+        _upload( image, 1, texture.u );
+        _upload( image, 2, texture.v );
+        return true;
+    }
+    default:
+        put_flog( LOG_DEBUG, "image has unsupported texture format" );
+        return false;
+    }
+}
 
-    // copy pixels from CPU mem to GPU mem
-    void* pboData = _gl->glMapBuffer( GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY );
-    std::memcpy( pboData, image.getData(), bufferSize );
-    _gl->glUnmapBuffer( GL_PIXEL_UNPACK_BUFFER );
+void TextureUploader::_upload( const Image& image, const uint srcTextureIdx,
+                               const uint textureID )
+{
+    const auto textureSize = image.getSize( srcTextureIdx );
 
-    // setup PBO and texture pixel storage
     GLint alignment = 1;
-    if( (image.getWidth() % 4) == 0 )
+    if( (textureSize.width() % 4) == 0 )
         alignment = 4;
-    else if( (image.getWidth() % 2) == 0 )
+    else if( (textureSize.width() % 2) == 0 )
         alignment = 2;
     _gl->glPixelStorei( GL_UNPACK_ALIGNMENT, alignment );
-    _gl->glPixelStorei( GL_UNPACK_ROW_LENGTH, image.getWidth( ));
 
-    // update texture with pixels from PBO
-    _gl->glActiveTexture( GL_TEXTURE0 );
     _gl->glBindTexture( GL_TEXTURE_2D, textureID );
-    _gl->glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, image.getWidth(),
-                          image.getHeight(), image.getFormat(),
-                          GL_UNSIGNED_BYTE, 0 );
-
-    _gl->glBindBuffer( GL_PIXEL_UNPACK_BUFFER, 0 );
-#else
-    GLint alignment = 1;
-    if( (image.getWidth() % 4) == 0 )
-        alignment = 4;
-    else if( (image.getWidth() % 2) == 0 )
-        alignment = 2;
-    _gl->glPixelStorei( GL_UNPACK_ALIGNMENT, alignment );
-
-    _gl->glActiveTexture( GL_TEXTURE0 );
-    _gl->glBindTexture( GL_TEXTURE_2D, textureID );
-    _gl->glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, image.getWidth(),
-                          image.getHeight(), image.getFormat(),
-                          GL_UNSIGNED_BYTE, image.getData( ));
-#endif
+    _gl->glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, textureSize.width(),
+                          textureSize.height(), image.getGLPixelFormat(),
+                          GL_UNSIGNED_BYTE, image.getData( srcTextureIdx ));
     _gl->glGenerateMipmap( GL_TEXTURE_2D );
 
     _gl->glBindTexture( GL_TEXTURE_2D, 0 );

--- a/tide/wall/TextureUploader.h
+++ b/tide/wall/TextureUploader.h
@@ -90,7 +90,8 @@ private slots:
     void _onStop();
 
 private:
-    void _upload( const Image& image, uint textureID );
+    bool _upload( const Image& image, const Tile& tile );
+    void _upload( const Image& image, uint srcTexture, uint textureID );
 
     std::unique_ptr<QOpenGLContext> _glContext;
     std::unique_ptr<QOffscreenSurface> _offscreenSurface;

--- a/tide/wall/Tile.h
+++ b/tide/wall/Tile.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -42,11 +42,14 @@
 
 #include "types.h"
 
+#include "YUVTexture.h"
+
 #include <QQuickItem>
 #include <memory> // std::enable_shared_from_this
 
-class TextureNode;
 class QuadLineNode;
+class TextureNode;
+class TextureNodeYUV;
 
 /**
  * Qml item to render an image tile with texture double-buffering.
@@ -71,11 +74,16 @@ public:
      * Constructor
      * @param id the unique identifier for this tile
      * @param rect the nominal size of the tile's texture
+     * @param format the texture format to use for rendering
      */
-    Tile( uint id, const QRect& rect );
+    Tile( uint id, const QRect& rect,
+          TextureFormat format = TextureFormat::rgba );
 
     /** @return the unique identifier for this tile. */
     uint getId() const;
+
+    /** @return the texture format for this tile. */
+    TextureFormat getFormat() const;
 
     /** @return true if this tile displays its borders. */
     bool getShowBorder() const;
@@ -88,6 +96,9 @@ public:
 
     /** @return the back texture's identifier. */
     uint getBackGlTexture() const;
+
+    /** @return the back YUV texture's identifiers. */
+    const YUVTexture& getBackGlTextureYUV() const;
 
     /** @return the dimensions of the back texture. */
     QSize getBackGlTextureSize() const;
@@ -131,6 +142,7 @@ protected:
 
 private:
     const uint _tileId;
+    const TextureFormat _format;
     SizePolicy _policy;
 
     bool _swapRequested;
@@ -138,11 +150,20 @@ private:
     QRect _nextCoord;
 
     uint _backGlTexture;
+    YUVTexture _backGlTextureYUV;
 
     bool _showBorder;
     QuadLineNode* _border;
 
-    void _updateBorderNode( TextureNode* parentNode );
+    template<class NodeT>
+    QSGNode* _updateTextureNode( QSGNode* oldNode );
+
+    void _storeBackTextureIndex( const TextureNode& node );
+    void _storeBackTextureIndex( const TextureNodeYUV& node );
+
+    template<class NodeT>
+    void _updateBorderNode( NodeT* parentNode );
+
     void _onParentChanged( QQuickItem* newParent );
 
     QMetaObject::Connection _widthConn;

--- a/tide/wall/YUVTexture.h
+++ b/tide/wall/YUVTexture.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,47 +37,20 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#include "SVGGpuImage.h"
+#ifndef YUVTEXTURE_H
+#define YUVTEXTURE_H
 
-SVGGpuImage::SVGGpuImage( const SVGTiler& dataSource, const uint tileId )
-    : _dataSource( dataSource )
-    , _tileId( tileId )
-{}
-
-int SVGGpuImage::getWidth() const
+/**
+ * A YUV texture composed of three OpenGL texture indices.
+ */
+struct YUVTexture
 {
-    return _image->getWidth();
-}
+    int y = 0;
+    int u = 0;
+    int v = 0;
 
-int SVGGpuImage::getHeight() const
-{
-    return _image->getHeight();
-}
+    YUVTexture() = default;
+    YUVTexture( int y_, int u_, int v_ ) : y{ y_ }, u{ u_ }, v{ v_ } {}
+};
 
-const uint8_t* SVGGpuImage::getData( const uint texture ) const
-{
-    Q_UNUSED( texture );
-    return _image->getData();
-}
-
-TextureFormat SVGGpuImage::getFormat() const
-{
-    return TextureFormat::rgba;
-}
-
-uint SVGGpuImage::getGLPixelFormat() const
-{
-    return _image->getGLPixelFormat();
-}
-
-bool SVGGpuImage::isGpuImage() const
-{
-    return true;
-}
-
-bool SVGGpuImage::generateGpuImage()
-{
-    // Call getTileImage so that the image gets cached for the next request
-    _image = _dataSource.getTileImage( _tileId );
-    return true;
-}
+#endif


### PR DESCRIPTION
Also decoupled FFMPEGPicture from FFMPEGFrame and removed some deprecated methods from the ffmpeg api.

It should also be possible to use the GPU YUV->RGBA conversion of delfect PixelStreams with minimal code changes.