### PR TITLE
fixing session loading from launcher

### DIFF
--- a/apps/Launcher/qml/main.qml
+++ b/apps/Launcher/qml/main.qml
@@ -72,8 +72,7 @@ Rectangle {
         id: sessionsBrowser
         FileBrowser {
             onItemSelected: {
-                var nextCommand = function() { sendRestCommand("load", file); };
-                sendRestCommand("load", "", nextCommand);
+                sendRestCommand("load", file);
             }
             rootfolder: rootSessionsFolder
             nameFilters: ["*.dcx"]


### PR DESCRIPTION
"load" action with no payload does not clear the display group. adapting to "clear"