### PR TITLE
Bugfix: relocated contents not using the updated uri on the wall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(TIDE_DESCRIPTION "Tiled Interactive DisplayWall Environment")
 set(TIDE_MAINTAINER "Blue Brain Project <bbp-open-source@googlegroups.com>")
 set(TIDE_VENDOR "Blue Brain Project")
 set(TIDE_LICENSE BSD)
-set(TIDE_DEB_DEPENDS python libopenmpi-dev openmpi-bin
+set(TIDE_DEB_DEPENDS python imagemagick libopenmpi-dev openmpi-bin
   libboost-program-options-dev libboost-serialization-dev libboost-test-dev
   qtbase5-dev qtdeclarative5-dev libqt5svg5-dev libqt5webkit5-dev
   libqt5xmlpatterns5-dev libqt5x11extras5-dev qml-module-qtquick-controls

--- a/tide/core/scene/ContentWindow.cpp
+++ b/tide/core/scene/ContentWindow.cpp
@@ -301,5 +301,6 @@ void ContentWindow::_init()
 {
     setResizePolicy(_content->hasFixedAspectRatio() ? KEEP_ASPECT_RATIO
                                                     : ADJUST_CONTENT);
-    connect(_content.get(), SIGNAL(modified()), SIGNAL(contentModified()));
+    connect(_content.get(), &Content::modified, this,
+            &ContentWindow::contentModified);
 }

--- a/tide/master/resources/js/tide.js
+++ b/tide/master/resources/js/tide.js
@@ -441,7 +441,6 @@ function getOptions() {
 }
 
 function getSessionFolderContent() {
-
   var url = restUrl + "sessions/";
   var xhr = new XMLHttpRequest();
   var data;
@@ -823,10 +822,13 @@ function saveSession() {
       showCancelButton: true
     },
     function () {
-      requestPUT("save", params, getSessionFolderContent);
+      requestPUT("save", params, function(){
+          getSessionFolderContent();
+          updateWall(); // contents may have been relocated changing some window UUIDs
+      });
       swal({
         title: "Saved!",
-        text: "Your file has been saved as: " + uri,
+        text: "Your session has been saved as: " + uri,
         type: "success",
         confirmButtonText: "OK",
         confirmButtonColor: "#014f86"


### PR DESCRIPTION
This could cause for instance uploaded PDFs to appear black after saving the session.