### PR TITLE
Performance improvement for PixelStreams with small tile size

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.4 (git 1.4-dev)
 
+* [169](https://github.com/BlueBrain/Tide/issues/169):
+  Performance improvement for PixelStreams with small tile size (64x64).
 * [162](https://github.com/BlueBrain/Tide/issues/162):
   Movies and pixel streams can be rendered at 60 fps (up from 30 fps).
 * [161](https://github.com/BlueBrain/Tide/issues/161):

--- a/tests/cpp/core/PixelStreamAssemblerTests.cpp
+++ b/tests/cpp/core/PixelStreamAssemblerTests.cpp
@@ -1,0 +1,259 @@
+/*********************************************************************/
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of Ecole polytechnique federale de Lausanne.          */
+/*********************************************************************/
+
+#define BOOST_TEST_MODULE PixelStreamAssemblerTests
+#include <boost/test/unit_test.hpp>
+
+#include "tide/core/data/Image.h"
+#include "tide/wall/PixelStreamAssembler.h"
+
+#include <deflect/Frame.h>
+#include <deflect/SegmentDecoder.h>
+
+#include <cmath> //std::ceil
+
+namespace
+{
+const int SEGMENT_SIZE = 64;
+
+QByteArray createBuffer(const int size, const int seed)
+{
+    QByteArray buffer;
+    assert(size % 8 == 0);
+    for (int i = 0; i < size; i += 8)
+    {
+        buffer.append(seed + 0);
+        buffer.append(seed + 1);
+        buffer.append(seed + 2);
+        buffer.append(seed + 3);
+        buffer.append(seed + 4);
+        buffer.append(seed + 5);
+        buffer.append(seed + 6);
+        buffer.append(seed + 7);
+    }
+    return buffer;
+}
+
+const QByteArray expectedY = createBuffer(512 * 512, 92);
+const QByteArray expectedU = createBuffer(512 * 512, 28);
+const QByteArray expectedV = createBuffer(512 * 512, 79);
+const QByteArray expectedRGBA = createBuffer(512 * 512 * 4, 112);
+
+deflect::DataType getDataType(const int subsamp)
+{
+    switch (subsamp)
+    {
+    case -1:
+        return deflect::DataType::rgba;
+    case 0:
+        return deflect::DataType::yuv444;
+    case 1:
+        return deflect::DataType::yuv422;
+    case 2:
+        return deflect::DataType::yuv420;
+    default:
+        throw std::runtime_error("Invalid subsampling");
+    }
+}
+
+TextureFormat getTextureFormat(const int subsamp)
+{
+    switch (subsamp)
+    {
+    case -1:
+        return TextureFormat::rgba;
+    case 0:
+        return TextureFormat::yuv444;
+    case 1:
+        return TextureFormat::yuv422;
+    case 2:
+        return TextureFormat::yuv420;
+    default:
+        throw std::runtime_error("Invalid subsampling");
+    }
+}
+
+deflect::Segment createSegment(const QPoint& pos, const QSize& size,
+                               const int subsamp)
+{
+    deflect::Segment segment;
+    segment.parameters.dataType = getDataType(subsamp);
+    segment.parameters.x = pos.x();
+    segment.parameters.y = pos.y();
+    segment.parameters.width = size.width();
+    segment.parameters.height = size.height();
+
+    if (subsamp == -1)
+    {
+        const auto rgbaSize = size.width() * size.height() * 4;
+        segment.imageData.append(createBuffer(rgbaSize, 112)); // RGBA
+    }
+    else
+    {
+        const auto ySize = size.width() * size.height();
+        const auto uvSize = ySize >> subsamp;
+        segment.imageData.append(createBuffer(ySize, 92));  // Y
+        segment.imageData.append(createBuffer(uvSize, 28)); // U
+        segment.imageData.append(createBuffer(uvSize, 79)); // V
+    }
+    return segment;
+}
+
+deflect::FramePtr createTestFrame(const QSize& size, const int subsamp)
+{
+    deflect::FramePtr frame(new deflect::Frame);
+
+    const int segmentsX = std::ceil(float(size.width()) / SEGMENT_SIZE);
+    const int segmentsY = std::ceil(float(size.height()) / SEGMENT_SIZE);
+
+    auto borderX = size.width() % SEGMENT_SIZE;
+    if (borderX == 0)
+        borderX = SEGMENT_SIZE;
+
+    auto borderY = size.height() % SEGMENT_SIZE;
+    if (borderY == 0)
+        borderY = SEGMENT_SIZE;
+
+    for (int y = 0; y < segmentsY; ++y)
+    {
+        for (int x = 0; x < segmentsX; ++x)
+        {
+            const QPoint pos{x * SEGMENT_SIZE, y * SEGMENT_SIZE};
+            const QSize segSize{x < segmentsX - 1 ? SEGMENT_SIZE : borderX,
+                                y < segmentsY - 1 ? SEGMENT_SIZE : borderY};
+            frame->segments.push_back(createSegment(pos, segSize, subsamp));
+        }
+    }
+    return frame;
+}
+
+inline void checkData(const Image& image, const int subsamp)
+{
+    if (subsamp == -1) // RGBA
+    {
+        const auto size = image.getWidth() * image.getHeight() * 4;
+        const auto data = image.getData(0);
+        BOOST_CHECK_EQUAL_COLLECTIONS(data, data + size, expectedRGBA.data(),
+                                      expectedRGBA.data() + size);
+    }
+    else // YUV
+    {
+        const auto sizeY = image.getWidth() * image.getHeight();
+        const auto sizeUV = sizeY / (1 << subsamp);
+        const auto dataY = image.getData(0);
+        const auto dataU = image.getData(1);
+        const auto dataV = image.getData(2);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(dataY, dataY + sizeY, expectedY.data(),
+                                      expectedY.data() + sizeY);
+        BOOST_CHECK_EQUAL_COLLECTIONS(dataU, dataU + sizeUV, expectedU.data(),
+                                      expectedU.data() + sizeUV);
+        BOOST_CHECK_EQUAL_COLLECTIONS(dataV, dataV + sizeUV, expectedV.data(),
+                                      expectedV.data() + sizeUV);
+    }
+}
+}
+
+BOOST_AUTO_TEST_CASE(testAssembleStreamImageYUVandRGBA)
+{
+#ifndef DEFLECT_USE_LEGACY_LIBJPEGTURBO
+    for (auto subsamp = -1; subsamp <= 2; ++subsamp)
+#else
+    const int subsamp = -1; // Only RGBA can be tested
+#endif
+    {
+        const auto frame = createTestFrame({640, 900}, subsamp);
+        const auto textureFormat = getTextureFormat(subsamp);
+
+        BOOST_REQUIRE_EQUAL(frame->segments.size(), 10 * 15);
+        BOOST_REQUIRE_EQUAL(frame->computeDimensions(), QSize(640, 900));
+        BOOST_REQUIRE_NO_THROW(PixelStreamAssembler{frame});
+
+        // Check indices
+        PixelStreamAssembler assembler{frame};
+        auto indices = assembler.computeVisibleSet(QRectF{0, 0, 0, 0});
+        BOOST_CHECK_EQUAL(indices.size(), 0);
+        indices = assembler.computeVisibleSet(QRectF{64, 64, 576, 512 - 64});
+        BOOST_CHECK_EQUAL(indices.size(), 2);
+        indices = assembler.computeVisibleSet(QRectF{0, 0, 640, 900});
+        BOOST_CHECK_EQUAL(indices.size(), 4);
+
+        // Check format
+        deflect::SegmentDecoder decoder;
+        for (auto tileIndex : indices)
+        {
+            BOOST_CHECK_EQUAL((int)assembler.getTileFormat(tileIndex, decoder),
+                              (int)textureFormat);
+        }
+
+        // Check rectangles
+        BOOST_CHECK_EQUAL(assembler.getTileRect(0), QRect(0, 0, 512, 512));
+        BOOST_CHECK_EQUAL(assembler.getTileRect(1),
+                          QRect(512, 0, 640 - 512, 512));
+        BOOST_CHECK_EQUAL(assembler.getTileRect(2),
+                          QRect(0, 512, 512, 900 - 512));
+        BOOST_CHECK_EQUAL(assembler.getTileRect(3),
+                          QRect(512, 512, 640 - 512, 900 - 512));
+
+        // Check images
+        const auto image0 = assembler.getTileImage(0, decoder);
+        BOOST_CHECK_EQUAL(image0->getWidth(), 512);
+        BOOST_CHECK_EQUAL(image0->getHeight(), 512);
+        BOOST_CHECK_EQUAL((int)image0->getFormat(), (int)textureFormat);
+        checkData(*image0, subsamp);
+
+        const auto image1 = assembler.getTileImage(1, decoder);
+        BOOST_CHECK_EQUAL(image1->getWidth(), 640 - 512);
+        BOOST_CHECK_EQUAL(image1->getHeight(), 512);
+        BOOST_CHECK_EQUAL((int)image1->getFormat(), (int)textureFormat);
+        checkData(*image1, subsamp);
+
+        const auto image2 = assembler.getTileImage(2, decoder);
+        BOOST_CHECK_EQUAL(image2->getWidth(), 512);
+        BOOST_CHECK_EQUAL(image2->getHeight(), 900 - 512);
+        BOOST_CHECK_EQUAL((int)image2->getFormat(), (int)textureFormat);
+        checkData(*image2, subsamp);
+
+        const auto image3 = assembler.getTileImage(3, decoder);
+        BOOST_CHECK_EQUAL(image3->getWidth(), 640 - 512);
+        BOOST_CHECK_EQUAL(image3->getHeight(), 900 - 512);
+        BOOST_CHECK_EQUAL((int)image3->getFormat(), (int)textureFormat);
+        checkData(*image3, subsamp);
+    }
+}

--- a/tide/wall/CMakeLists.txt
+++ b/tide/wall/CMakeLists.txt
@@ -58,6 +58,9 @@ list(APPEND TIDEWALL_PUBLIC_HEADERS
   network/WallFromMasterChannel.h
   network/WallToMasterChannel.h
   network/WallToWallChannel.h
+  PixelStreamAssembler.h
+  PixelStreamProcessor.h
+  PixelStreamPassthrough.h
   PixelStreamSynchronizer.h
   PixelStreamUpdater.h
   QmlWindowRenderer.h
@@ -94,6 +97,9 @@ list(APPEND TIDEWALL_SOURCES
   network/WallFromMasterChannel.cpp
   network/WallToMasterChannel.cpp
   network/WallToWallChannel.cpp
+  PixelStreamAssembler.cpp
+  PixelStreamProcessor.cpp
+  PixelStreamPassthrough.cpp
   PixelStreamSynchronizer.cpp
   PixelStreamUpdater.cpp
   QmlWindowRenderer.cpp

--- a/tide/wall/PixelStreamAssembler.cpp
+++ b/tide/wall/PixelStreamAssembler.cpp
@@ -1,0 +1,251 @@
+/*********************************************************************/
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of Ecole polytechnique federale de Lausanne.          */
+/*********************************************************************/
+
+#include "PixelStreamAssembler.h"
+
+#include "StreamImage.h"
+#include "log.h"
+
+#include <deflect/SegmentDecoder.h>
+
+#include <cmath> //std::ceil
+
+namespace
+{
+const uint32_t targetTileSize = 512;
+
+bool _isValidSize(const uint32_t size)
+{
+    return size < targetTileSize && targetTileSize % size == 0;
+}
+
+bool _isValidSubtile(const deflect::SegmentParameters& segment)
+{
+    return _isValidSize(segment.width) && _isValidSize(segment.height);
+}
+}
+
+PixelStreamAssembler::PixelStreamAssembler(deflect::FramePtr frame)
+    : _frame{frame}
+    , _frameSize{_frame->computeDimensions()}
+{
+    if (!_canAssemble())
+        throw std::runtime_error("This frame cannot be assembled");
+
+    _initTargetFrame();
+}
+
+TextureFormat PixelStreamAssembler::getTileFormat(
+    const uint tileIndex, deflect::SegmentDecoder& decoder) const
+{
+    const auto tiles = _findSourceTiles(tileIndex);
+    const auto& segment = _frame->segments.at(*tiles.begin());
+    return getFormat(segment, decoder);
+}
+
+ImagePtr PixelStreamAssembler::getTileImage(const uint tileIndex,
+                                            deflect::SegmentDecoder& decoder)
+{
+    const auto sourceTiles = _findSourceTiles(tileIndex);
+
+    _decodeSourceTiles(sourceTiles, decoder);
+    _assembleTargetTile(tileIndex, sourceTiles);
+
+    return std::make_shared<StreamImage>(_assembledFrame, tileIndex);
+}
+
+QRect PixelStreamAssembler::getTileRect(const uint tileIndex) const
+{
+    const uint tilesX = _getTilesX();
+    const uint tilesY = _getTilesY();
+    const uint x = tileIndex % tilesX;
+    const uint y = tileIndex / tilesX;
+    const uint paddingX = _frameSize.width() % targetTileSize;
+    const uint paddingY = _frameSize.height() % targetTileSize;
+    const uint w =
+        (x < tilesX - 1) || paddingX == 0 ? targetTileSize : paddingX;
+    const uint h =
+        (y < tilesY - 1) || paddingY == 0 ? targetTileSize : paddingY;
+    return QRect(x * targetTileSize, y * targetTileSize, w, h);
+}
+
+Indices PixelStreamAssembler::computeVisibleSet(
+    const QRectF& visibleTilesArea) const
+{
+    Indices visibleSet;
+    const auto tilesCount = _getTilesX() * _getTilesY();
+    for (uint tileIndex = 0; tileIndex < tilesCount; ++tileIndex)
+    {
+        if (visibleTilesArea.intersects(getTileRect(tileIndex)))
+            visibleSet.insert(tileIndex);
+    }
+    return visibleSet;
+}
+
+bool PixelStreamAssembler::_canAssemble() const
+{
+    const auto& sortedSegments = _frame->segments;
+    if (sortedSegments.size() <= 1)
+        return false;
+
+    const auto& firstSegment = sortedSegments[0].parameters;
+
+    if (!_isValidSubtile(firstSegment))
+        return false;
+
+    const auto tileWidth = firstSegment.width;
+    const auto tileHeight = firstSegment.height;
+
+    uint currentX = 0;
+    uint currentY = 0;
+    bool eol = false;
+
+    for (const auto& segment : sortedSegments)
+    {
+        const auto& seg = segment.parameters;
+
+        if (seg.y != currentY)
+        {
+            if (!eol || seg.y != currentY + tileHeight)
+                return false;
+            // Next line
+            currentY = seg.y;
+            currentX = 0;
+            eol = false;
+        }
+
+        if (seg.height != tileHeight)
+        {
+            if (currentY + seg.height != (uint)_frameSize.height())
+                return false;
+        }
+
+        if (seg.x != currentX)
+            return false;
+
+        if (seg.width != tileWidth ||
+            currentX + tileWidth >= (uint)_frameSize.width())
+        {
+            if (seg.x + seg.width != (uint)_frameSize.width())
+                return false;
+
+            eol = true;
+        }
+
+        currentX += seg.width;
+    }
+    return true;
+}
+
+uint PixelStreamAssembler::_getTilesX() const
+{
+    return std::ceil(float(_frameSize.width()) / targetTileSize);
+}
+
+uint PixelStreamAssembler::_getTilesY() const
+{
+    return std::ceil(float(_frameSize.height()) / targetTileSize);
+}
+
+void PixelStreamAssembler::_initTargetFrame()
+{
+    _assembledFrame.reset(new deflect::Frame);
+
+    const auto tilesCount = _getTilesX() * _getTilesY();
+    auto& segments = _assembledFrame->segments;
+    segments.resize(tilesCount);
+    for (size_t i = 0; i < tilesCount; ++i)
+    {
+        const auto tileRect = getTileRect(i);
+        segments[i].parameters.width = tileRect.width();
+        segments[i].parameters.height = tileRect.height();
+        segments[i].parameters.x = tileRect.x();
+        segments[i].parameters.y = tileRect.y();
+    }
+}
+
+Indices PixelStreamAssembler::_findSourceTiles(const uint tileIndex) const
+{
+    Indices indices;
+    const auto tileRect = getTileRect(tileIndex);
+    for (size_t i = 0; i < _frame->segments.size(); ++i)
+    {
+        const auto segmentRect = toRect(_frame->segments.at(i).parameters);
+        if (tileRect.intersects(segmentRect))
+            indices.insert(i);
+    }
+    return indices;
+}
+
+void PixelStreamAssembler::_decodeSourceTiles(const Indices& indices,
+                                              deflect::SegmentDecoder& decoder)
+{
+    for (auto i : indices)
+    {
+        auto& segment = _frame->segments.at(i);
+
+        if (segment.parameters.dataType == deflect::DataType::jpeg)
+#ifndef DEFLECT_USE_LEGACY_LIBJPEGTURBO
+            decoder.decodeToYUV(segment);
+#else
+            decoder.decode(segment);
+#endif
+    }
+}
+
+void PixelStreamAssembler::_assembleTargetTile(const uint tileIndex,
+                                               const Indices& indices)
+{
+    auto& target = _assembledFrame->segments[tileIndex];
+    if (!target.imageData.isEmpty())
+        return;
+
+    const auto type = _frame->segments[*indices.begin()].parameters.dataType;
+
+    StreamImage image{_assembledFrame, tileIndex};
+    target.parameters.dataType = type;
+    const auto dataSize =
+        image.getDataSize(0) + image.getDataSize(1) + image.getDataSize(2);
+    target.imageData.resize(dataSize);
+    for (auto i : indices)
+    {
+        const auto tile = StreamImage{_frame, (uint)i};
+        image.copy(tile, tile.getPosition() - image.getPosition());
+    }
+}

--- a/tide/wall/PixelStreamPassthrough.h
+++ b/tide/wall/PixelStreamPassthrough.h
@@ -1,7 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
-/*                          Daniel.Nachbaur@epfl.ch                  */
-/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -38,46 +37,39 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#ifndef STREAMIMAGE_H
-#define STREAMIMAGE_H
+#ifndef PIXELSTREAMPASSTHROUGH_H
+#define PIXELSTREAMPASSTHROUGH_H
 
-#include "data/YUVImage.h"
-
-#include <deflect/types.h>
+#include "PixelStreamProcessor.h"
 
 /**
- * Image wrapper for a pixel stream image.
+ * Pass tiles without modification for rendering.
  */
-class StreamImage : public YUVImage
+class PixelStreamPassthrough : public PixelStreamProcessor
 {
 public:
-    /** Constructor, stores the given deflect frame. */
-    StreamImage(deflect::FramePtr frame, uint tileIndex);
+    /**
+     * Construct a processor that does not modify the pixel stream.
+     * @param frame to decode and expose.
+     */
+    PixelStreamPassthrough(deflect::FramePtr frame);
 
-    /** @copydoc Image::getWidth */
-    int getWidth() const final;
+    /** @copydoc PixelStreamProcessor::getTileImage */
+    ImagePtr getTileImage(uint tileIndex,
+                          deflect::SegmentDecoder& decoder) final;
 
-    /** @copydoc Image::getHeight */
-    int getHeight() const final;
+    /** @copydoc PixelStreamProcessor::getTileRect */
+    QRect getTileRect(uint tileIndex) const final;
 
-    /** @copydoc Image::getData */
-    const uint8_t* getData(uint texture) const final;
+    /** @copydoc PixelStreamProcessor::getTileFormat */
+    TextureFormat getTileFormat(uint tileIndex,
+                                deflect::SegmentDecoder& decoder) const final;
 
-    /** @copydoc Image::getFormat */
-    TextureFormat getFormat() const final;
-
-    /** @return the position of the image in the stream. */
-    QPoint getPosition() const;
-
-    /** Copy another image of the same format at the given position. */
-    void copy(const StreamImage& source, const QPoint& position);
+    /** @copydoc PixelStreamProcessor::computeVisibleSet */
+    Indices computeVisibleSet(const QRectF& visibleTilesArea) const final;
 
 private:
-    const deflect::FramePtr _frame;
-    const uint _tileIndex;
-
-    void _copy(const StreamImage& image, uint texture, const QPoint& position);
-    uint8_t* _getData(const uint texture);
+    deflect::FramePtr _frame;
 };
 
 #endif

--- a/tide/wall/PixelStreamUpdater.h
+++ b/tide/wall/PixelStreamUpdater.h
@@ -43,11 +43,12 @@
 #include "types.h"
 
 #include "DataSource.h"
-#include "PixelStreamSynchronizer.h"
 #include "SwapSyncObject.h"
 
 #include <QObject>
 #include <QReadWriteLock>
+
+class PixelStreamProcessor;
 
 /**
  * Synchronize the update of PixelStreams and send new frame requests.
@@ -110,10 +111,13 @@ private:
     deflect::FramePtr _frameLeftOrMono;
     deflect::FramePtr _frameRight;
     std::unique_ptr<deflect::SegmentDecoder> _headerDecoder;
+    std::unique_ptr<PixelStreamProcessor> _processorLeft;
+    std::unique_ptr<PixelStreamProcessor> _processRight;
     mutable QReadWriteLock _frameMutex;
     bool _readyToSwap = true;
 
     void _onFrameSwapped(deflect::FramePtr frame);
+    void _createFrameProcessors();
 };
 
 #endif


### PR DESCRIPTION
The performance of Tide drops dramatically when too many tiles are displayed. This commit adds a merge step to the wall processes to assemble small tiles (e.g. 64x64) into larger ones (512x512).

This change was made necessary by the OSPRay-Deflect module which streams 64x64 tiles directly, bypassing the frame assembly step.