### PR TITLE
Fixed launch in multi-node configuration

### DIFF
--- a/apps/tide
+++ b/apps/tide
@@ -165,8 +165,8 @@ try:
         node_host = '%s %s' % (MPI_PER_NODE_HOST, host)
     else:
         node_host = ''
+        forker_host = host    # forker must go at the end of the hostlist
         hostlist.append(host) # master
-        hostlist.append(host) # forker
 
     export_display = EXPORT_ENV_VAR.format('DISPLAY', display)
     environment = '%s %s %s' % (MPI_SPECIAL_FLAGS, export_display, node_host)
@@ -204,6 +204,8 @@ try:
         runcommands.append(wallcmd)
 
     # the 'forker' process is the last one
+    if not MPI_PER_NODE_HOST:
+        hostlist.append(forker_host)
     runcommands.append(forkercmd)
 
 except Exception as e:

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.3.1 (git master)
 
+* [170](https://github.com/BlueBrain/Tide/pull/170):
+  Bugfix: in multi-node configurations some windows opened on incorrect hosts.
 * [168](https://github.com/BlueBrain/Tide/pull/168):
   Tide will log now a timestamp of an event along with the logger id. 
 * [165](https://github.com/BlueBrain/Tide/pull/165):


### PR DESCRIPTION
The forker command was last but it's host was appended to the MPI hostlist between the master and wall processes, shifting the wall processes order.