### PR TITLE
Actually fix launch with OpenMPI in multi-node configuration

### DIFF
--- a/apps/tide
+++ b/apps/tide
@@ -93,24 +93,28 @@ IS_MPICH2 = distutils.spawn.find_executable('mpich2version')
 IS_MPICH3 = distutils.spawn.find_executable('mpichversion')
 if IS_MVAPICH:
     MPI_SPECIAL_FLAGS = '-env MV2_ENABLE_AFFINITY 0 -env IPATH_NO_CPUAFFINITY 1'
+    MPI_GLOBAL_HOST_LIST = '-hosts'
     MPI_PER_NODE_HOST = None
     EXPORT_ENV_VAR = '-env {0} {1}'
-    mpi_args += '-genvlist MPIEXEC_SIGNAL_PROPAGATION,LD_LIBRARY_PATH -hosts'
+    mpi_args += '-genvlist MPIEXEC_SIGNAL_PROPAGATION,LD_LIBRARY_PATH'
 elif IS_MPICH2:
     MPI_SPECIAL_FLAGS = '-env MV2_ENABLE_AFFINITY 0 -env IPATH_NO_CPUAFFINITY 1'
+    MPI_GLOBAL_HOST_LIST = None
     MPI_PER_NODE_HOST = '-host'
     EXPORT_ENV_VAR = '-env {0} {1}'
     mpi_args += '-genvlist LD_LIBRARY_PATH'
 elif IS_MPICH3:
     MPI_SPECIAL_FLAGS = '-env MV2_ENABLE_AFFINITY 0 -env IPATH_NO_CPUAFFINITY 1'
+    MPI_GLOBAL_HOST_LIST = '-hosts'
     MPI_PER_NODE_HOST = None
     EXPORT_ENV_VAR = '-env {0} {1}'
-    mpi_args += '-genvlist LD_LIBRARY_PATH -hosts'
-else:
+    mpi_args += '-genvlist LD_LIBRARY_PATH'
+else: # OpenMPI
     MPI_SPECIAL_FLAGS = '-x IPATH_NO_CPUAFFINITY=1'
-    MPI_PER_NODE_HOST = None
+    MPI_GLOBAL_HOST_LIST = '-host'
+    MPI_PER_NODE_HOST = '-H'
     EXPORT_ENV_VAR = '-x {0}={1}'
-    mpi_args += '--mca hwloc_base_binding_policy none -x LD_LIBRARY_PATH -host'
+    mpi_args += '--mca hwloc_base_binding_policy none -x LD_LIBRARY_PATH'
     # "hwloc_base_binding_policy none" is equivalent to the new "--bind-to none"
     # option in OpenMPI >= 1.8, while being accepted by older versions as well.
     # It does nothing in that case, but the (now deprecated) "--bind-to-none"
@@ -165,8 +169,10 @@ try:
         node_host = '%s %s' % (MPI_PER_NODE_HOST, host)
     else:
         node_host = ''
-        forker_host = host    # forker must go at the end of the hostlist
+
+    if MPI_GLOBAL_HOST_LIST:
         hostlist.append(host) # master
+        forker_host = host    # forker goes at the end of the hostlist
 
     export_display = EXPORT_ENV_VAR.format('DISPLAY', display)
     environment = '%s %s %s' % (MPI_SPECIAL_FLAGS, export_display, node_host)
@@ -196,6 +202,8 @@ try:
             node_host = '%s %s' % (MPI_PER_NODE_HOST, host)
         else:
             node_host = ''
+
+        if MPI_GLOBAL_HOST_LIST:
             hostlist.append(host)
 
         export_display = EXPORT_ENV_VAR.format('DISPLAY', display)
@@ -204,7 +212,7 @@ try:
         runcommands.append(wallcmd)
 
     # the 'forker' process is the last one
-    if not MPI_PER_NODE_HOST:
+    if MPI_GLOBAL_HOST_LIST:
         hostlist.append(forker_host)
     runcommands.append(forkercmd)
 
@@ -212,9 +220,12 @@ except Exception as e:
     print("Error processing xml configuration '%s'. (%s)" % (TIDE_CONFIG_FILE, e))
     exit(-2)
 
-HOST_LIST = ",".join(hostlist)
-RUN_COMMANDS = ' : '.join(runcommands)
+if MPI_GLOBAL_HOST_LIST:
+    HOST_LIST = '%s %s' % (MPI_GLOBAL_HOST_LIST, ",".join(hostlist))
+else:
+    HOST_LIST = ''
 
+RUN_COMMANDS = ' : '.join(runcommands)
 START_CMD = '%s %s %s %s' % (MPIRUN_CMD, mpi_args, HOST_LIST, RUN_COMMANDS)
 
 if args.printcmd:

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,7 +3,7 @@ Changelog {#changelog}
 
 # Release 1.3.1 (git master)
 
-* [170](https://github.com/BlueBrain/Tide/pull/170):
+* [171](https://github.com/BlueBrain/Tide/pull/171):
   Bugfix: in multi-node configurations some windows opened on incorrect hosts.
 * [168](https://github.com/BlueBrain/Tide/pull/168):
   Tide will log now a timestamp of an event along with the logger id. 


### PR DESCRIPTION
OpenMPI needs both a global list of hosts (the order of which has to be more-or-less correct, but is partially ignored) and a per-node host specification. Otherwise the assignments are wrong.