### PR TITLE
Fix missing header include (issue while compiling with clang on OS X)

### DIFF
--- a/tide/master/ContentLoader.cpp
+++ b/tide/master/ContentLoader.cpp
@@ -46,6 +46,7 @@
 #include "scene/DisplayGroup.h"
 
 #include <QDir>
+#include <cmath>
 
 ContentLoader::ContentLoader(DisplayGroupPtr displayGroup)
     : _displayGroup(displayGroup)

--- a/tide/master/control/ContentWindowController.cpp
+++ b/tide/master/control/ContentWindowController.cpp
@@ -45,6 +45,8 @@
 #include "scene/ContentWindow.h"
 #include "scene/DisplayGroup.h"
 
+#include <cmath>
+
 namespace
 {
 const qreal MIN_SIZE = 0.05;


### PR DESCRIPTION
Compiling on OS X with Apple clang 8.1 gives following errors: 

```
.....software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-8.1.0-apple/zeroeq-master-uhdssuqi3z7lzf3ux6b4yrm4qn7kohrq/include  -O2 -g -DNDEBUG -arch x86_64 -fPIC   -DNDEBUG -Wnon-virtual-dtor -Wsign-promo -Wvla -fno-strict-aliasing -Wall -Wextra -Winvalid-pch -Winit-self -Wno-unknown-pragmas -Wshadow -Werror -Qunused-arguments -ferror-limit=5 -ftemplate-depth-1024 -Wheader-hygiene -fPIC -std=gnu++11 -o CMakeFiles/TideMaster.dir/ContentLoader.cpp.o -c /Users/kumbhar/workarena/software/sources/spack/var/spack/stage/tide-master-xiid5u3ibfvunaobqzibpzaqwtoy4qs4/Tide/tide/master/ContentLoader.cpp
/Users/kumbhar/workarena/software/sources/spack/var/spack/stage/tide-master-xiid5u3ibfvunaobqzibpzaqwtoy4qs4/Tide/tide/master/ContentLoader.cpp:99:29: error: use of undeclared identifier 'sqrt'
    const auto w = int(ceil(sqrt(numElem)));
```

```
.....de/master/control/ContentWindowController.cpp
/Users/kumbhar/workarena/software/sources/spack/var/spack/stage/tide-master-xiid5u3ibfvunaobqzibpzaqwtoy4qs4/Tide/tide/master/control/ContentWindowController.cpp:321:12: error: no member named 'fabs' in namespace 'std'; did you mean simply 'fabs'?
    return std::fabs(windowAR - contentAR) < ONE_PERCENT;
           ^~~~~~~~~
           fabs
/usr/include/math.h:431:15: note: 'fabs' declared here
extern double fabs(double);
```