### PR TITLE
OpenMPI: Fix export of LD_LIBRARY_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #                          Raphael Dumusc <raphael.dumusc@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(Tide VERSION 1.4.0)
+project(Tide VERSION 1.4.1)
 set(Tide_VERSION_ABI 1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/common)

--- a/apps/tide
+++ b/apps/tide
@@ -111,6 +111,8 @@ elif IS_MPICH3:
     mpi_args += '-genvlist LD_LIBRARY_PATH'
 else: # OpenMPI
     MPI_SPECIAL_FLAGS = '-x IPATH_NO_CPUAFFINITY=1'
+    if os.getenv("LD_LIBRARY_PATH"): # set and not empty
+        MPI_SPECIAL_FLAGS += ' -x LD_LIBRARY_PATH'
     MPI_GLOBAL_HOST_LIST = '-host'
     MPI_PER_NODE_HOST = '-H'
     EXPORT_ENV_VAR = '-x {0}={1}'
@@ -119,8 +121,6 @@ else: # OpenMPI
     # It does nothing in that case, but the (now deprecated) "--bind-to-none"
     # was the default anyways.
     mpi_args += '--mca hwloc_base_binding_policy none'
-    if 'LD_LIBRARY_PATH' in os.environ:
-        mpi_args += ' -x LD_LIBRARY_PATH'
 
 # Form the application parameters list
 TIDE_PARAMS = '--config ' + TIDE_CONFIG_FILE

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -1,6 +1,11 @@
 Changelog {#changelog}
 ============
 
+# Release 1.4.1 (git 1.4)
+
+* [215](https://github.com/BlueBrain/Tide/pull/215):
+  OpenMPI: Fix export of LD_LIBRARY_PATH.
+
 # Release 1.4 (09-11-2017)
 
 * [203](https://github.com/BlueBrain/Tide/pull/203):


### PR DESCRIPTION
Backported from master branch for a new OpenDeck package. Tide can't be launched easily on multiple nodes without this because Qt 5.8 is not in path on remote hosts.