### PR TITLE
Bugfix: play/pause buttons did not work on movies loaded from session

### DIFF
--- a/tide/core/scene/Content.cpp
+++ b/tide/core/scene/Content.cpp
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2015, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */

--- a/tide/core/scene/Content.h
+++ b/tide/core/scene/Content.h
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2015, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -91,7 +91,7 @@ public:
     /** Constructor **/
     Content(const QString& uri);
 
-    /** Make a clone of this Content (virtual copy constructor). */
+    /** Make a clone of this Content using binary serialization. */
     ContentPtr clone() const;
 
     /** Get the content URI **/

--- a/tide/core/scene/ContentActionsModel.cpp
+++ b/tide/core/scene/ContentActionsModel.cpp
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -76,8 +76,8 @@ int ContentActionsModel::rowCount(const QModelIndex& parent_) const
     return _actions.size();
 }
 
-void ContentActionsModel::add(ContentAction* action)
+void ContentActionsModel::add(std::unique_ptr<ContentAction> action)
 {
-    _actions.push_back(action);
-    action->setParent(this);
+    _actions.push_back(action.get());
+    action.release()->setParent(this);
 }

--- a/tide/core/scene/ContentActionsModel.h
+++ b/tide/core/scene/ContentActionsModel.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -60,7 +60,7 @@ public:
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
     /** Add an action and retains ownership by setting itself as the parent. */
-    void add(ContentAction* action);
+    void add(std::unique_ptr<ContentAction> action);
 
 private:
     friend class boost::serialization::access;

--- a/tide/core/scene/ContentWindow.h
+++ b/tide/core/scene/ContentWindow.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
 /* Copyright (c) 2011-2012, The University of Texas at Austin.       */
-/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
@@ -47,6 +47,7 @@
 #include "Content.h"   // member, needed for serialization
 #include "Rectangle.h" // base class
 #include "serialization/includes.h"
+#include "serialization/utils.h"
 
 #include <QUuid>
 
@@ -342,7 +343,7 @@ private:
     {
         std::shared_ptr<Content> tmp;
         ar >> boost::serialization::make_nvp("content", tmp);
-        setContent(tmp->clone());
+        setContent(ContentPtr{serialization::xmlCopy(tmp.get())});
     }
 
     void serialize_content_as_shared_ptr(boost::archive::xml_oarchive& ar)

--- a/tide/core/scene/MovieContent.cpp
+++ b/tide/core/scene/MovieContent.cpp
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -168,14 +168,14 @@ void MovieContent::_pause()
 
 void MovieContent::_createActions()
 {
-    ContentAction* playPauseAction = new ContentAction();
+    auto playPauseAction = make_unique<ContentAction>();
     playPauseAction->setCheckable(true);
     playPauseAction->setIcon(ICON_PAUSE);
     playPauseAction->setIconChecked(ICON_PLAY);
     playPauseAction->setChecked(_controlState & STATE_PAUSED);
-    connect(playPauseAction, &ContentAction::checked, this,
+    connect(playPauseAction.get(), &ContentAction::checked, this,
             &MovieContent::_pause);
-    connect(playPauseAction, &ContentAction::unchecked, this,
+    connect(playPauseAction.get(), &ContentAction::unchecked, this,
             &MovieContent::_play);
-    _actions.add(playPauseAction);
+    _actions.add(std::move(playPauseAction));
 }

--- a/tide/core/scene/MovieContent.h
+++ b/tide/core/scene/MovieContent.h
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -142,7 +142,9 @@ private:
                            const unsigned int version)
     {
         serialize_members_xml(ar, version);
-        _createActions(); // Need to be done after _controlState is restored
+        // Actions are not saved to xml file. Their creation need to be done
+        // after _controlState is restored.
+        _createActions();
     }
 
     /** Saving to xml. */

--- a/tide/core/scene/PixelStreamContent.cpp
+++ b/tide/core/scene/PixelStreamContent.cpp
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -51,11 +51,10 @@ const QString ICON_KEYBOARD("qrc:///img/keyboard.svg");
 }
 
 PixelStreamContent::PixelStreamContent(const QString& uri, const bool keyboard)
-    : Content(uri)
-    , _eventReceiversCount(0)
+    : Content{uri}
+    , _hasKeyboardAction{keyboard}
 {
-    if (keyboard)
-        _createActions();
+    _createActions();
 }
 
 CONTENT_TYPE PixelStreamContent::getType() const
@@ -90,13 +89,16 @@ void PixelStreamContent::incrementEventReceiverCount()
 
 void PixelStreamContent::_createActions()
 {
-    ContentAction* keyboardAction = new ContentAction();
+    if (!_hasKeyboardAction)
+        return;
+
+    auto keyboardAction = make_unique<ContentAction>();
     keyboardAction->setCheckable(true);
     keyboardAction->setIcon(ICON_KEYBOARD);
     keyboardAction->setIconChecked(ICON_KEYBOARD);
-    connect(keyboardAction, &ContentAction::triggered, &_keyboardState,
+    connect(keyboardAction.get(), &ContentAction::triggered, &_keyboardState,
             &KeyboardState::setVisible);
-    connect(&_keyboardState, &KeyboardState::visibleChanged, keyboardAction,
-            &ContentAction::setChecked);
-    _actions.add(keyboardAction);
+    connect(&_keyboardState, &KeyboardState::visibleChanged,
+            keyboardAction.get(), &ContentAction::setChecked);
+    _actions.add(std::move(keyboardAction));
 }

--- a/tide/core/scene/PixelStreamContent.h
+++ b/tide/core/scene/PixelStreamContent.h
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2011-2012, The University of Texas at Austin.       */
+/* Copyright (c) 2013-2018, EPFL/Blue Brain Project                  */
+/*                          Raphael.Dumusc@epfl.ch                   */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -56,7 +56,7 @@ public:
      * @param uri The unique stream identifier.
      * @param keyboard Show the keyboard action.
      */
-    explicit PixelStreamContent(const QString& uri, bool keyboard = true);
+    explicit PixelStreamContent(const QString& uri, bool keyboard);
 
     /** Get the content type **/
     CONTENT_TYPE getType() const override;
@@ -84,13 +84,15 @@ signals:
 
 protected:
     // Default constructor required for boost::serialization
+    // Derived classes can disable the keyboard action
     PixelStreamContent(const bool keyboard = true)
+        : _hasKeyboardAction{keyboard}
     {
-        if (keyboard)
-            _createActions();
     }
 
 private:
+    void _createActions();
+
     friend class boost::serialization::access;
 
     /** Serialize for sending to Wall applications. */
@@ -118,6 +120,7 @@ private:
                            const unsigned int version)
     {
         serialize_members_xml(ar, version);
+        _createActions(); // actions are not saved to xml file
     }
 
     /** Saving to xml. */
@@ -128,8 +131,7 @@ private:
     }
 
     unsigned int _eventReceiversCount = 0;
-
-    void _createActions();
+    bool _hasKeyboardAction = true;
 };
 
 DECLARE_SERIALIZE_FOR_XML(PixelStreamContent)


### PR DESCRIPTION
The bug was introduced in #216 by using a binary copy of MovieContent via Content::clone(). The binary copy did not (and should not) recreate the actions, as they are already serialized by Content when sending to the wall processes. They should only be created when making a new object on the master process, which includes loading from xml.

Other minor cleanups, including creating the actions for PixelStreamContents only when loading from xml to be consistent, even though in this case the the order of the operations was different so the problem was not visible.