### PR TITLE
Fix crash when opening movies with negative start time

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.4.1 (git 1.4)
 
+* [245](https://github.com/BlueBrain/Tide/pull/245):
+  Fix a crash when opening movies with negative start time.
 * [215](https://github.com/BlueBrain/Tide/pull/215):
   OpenMPI: Fix export of LD_LIBRARY_PATH.
 

--- a/tide/core/data/FFMPEGVideoStream.cpp
+++ b/tide/core/data/FFMPEGVideoStream.cpp
@@ -96,7 +96,7 @@ PicturePtr FFMPEGVideoStream::decode(AVPacket& packet,
 int64_t FFMPEGVideoStream::decodeTimestamp(AVPacket& packet)
 {
     if (!_decodeToAvFrame(packet))
-        return int64_t(-1);
+        return AV_NOPTS_VALUE;
 
     return _frame->getTimestamp();
 }


### PR DESCRIPTION
The previous "invalid" value of -1 for non-video packets was in fact still too large for a movie with a negative start time (most extreme value encountered in a valid movie: -823638).

This caused a non-video packet to be passed to the video frame converter, where sws_getCachedContext would abort the program on ffmpeg < 4.0 because the packet AVPixelFormat is unkown (-1).