### PR TITLE
Improve handling of error contents

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,9 @@ Changelog {#changelog}
 
 # Release 1.5 (git master)
 
+* [254](https://github.com/BlueBrain/Tide/pull/254):
+  Display the original title / file path of contents that fail to be restored
+  from a session.
 * [253](https://github.com/BlueBrain/Tide/pull/253):
   Fix occasional crash when generating thumbnails for small movies.
 * [250](https://github.com/BlueBrain/Tide/pull/250):

--- a/tests/cpp/core/DummyContent.h
+++ b/tests/cpp/core/DummyContent.h
@@ -79,6 +79,6 @@ private:
     }
 };
 
-BOOST_CLASS_EXPORT_GUID(DummyContent, "DummyContent")
+BOOST_CLASS_EXPORT(DummyContent)
 
 #endif

--- a/tide/core/CMakeLists.txt
+++ b/tide/core/CMakeLists.txt
@@ -154,6 +154,7 @@ list(APPEND TIDECORE_PUBLIC_HEADERS
   scene/CountdownStatus.h
   scene/DisplayGroup.h
   scene/DynamicTextureContent.h
+  scene/ErrorContent.h
   scene/KeyboardState.h
   scene/Markers.h
   scene/Options.h
@@ -215,6 +216,7 @@ list(APPEND TIDECORE_SOURCES
   scene/CountdownStatus.cpp
   scene/DisplayGroup.cpp
   scene/DynamicTextureContent.cpp
+  scene/ErrorContent.cpp
   scene/KeyboardState.cpp
   scene/Markers.cpp
   scene/Options.cpp

--- a/tide/core/resources/BaseContentWindow.qml
+++ b/tide/core/resources/BaseContentWindow.qml
@@ -64,7 +64,7 @@ Rectangle {
 
                     fontSizeMode: options.showFilePaths ? Text.Fit : Text.FixedSize
                     elide: options.showFilePaths ? Text.ElideLeft : Text.ElideRight
-                    text: options.showFilePaths ? contentwindow.content.uri : contentwindow.content.title
+                    text: options.showFilePaths ? contentwindow.content.filePath : contentwindow.content.title
                     font { family: "qrc::gotham-book"; pixelSize: Style.windowTitleFontSize }
                 }
             }

--- a/tide/core/scene/Content.cpp
+++ b/tide/core/scene/Content.cpp
@@ -77,9 +77,14 @@ const QString& Content::getURI() const
     return _uri;
 }
 
+QString Content::getFilePath() const
+{
+    return getURI();
+}
+
 QString Content::getTitle() const
 {
-    return getURI().section("/", -1, -1);
+    return getFilePath().section("/", -1, -1);
 }
 
 QSize Content::getDimensions() const

--- a/tide/core/scene/Content.h
+++ b/tide/core/scene/Content.h
@@ -67,6 +67,7 @@ class Content : public QObject
 
     // These properties are read-only on master and wall
     Q_PROPERTY(QString uri READ getURI CONSTANT)
+    Q_PROPERTY(QString filePath READ getFilePath CONSTANT)
     Q_PROPERTY(QString title READ getTitle NOTIFY titleChanged)
     Q_PROPERTY(bool hasFixedAspectRatio READ hasFixedAspectRatio CONSTANT)
     Q_PROPERTY(QString qmlControls READ getQmlControls CONSTANT)
@@ -104,6 +105,9 @@ public:
 
     /** Get the content type **/
     virtual CONTENT_TYPE getType() const = 0;
+
+    /** @return the full path to the content file. */
+    virtual QString getFilePath() const;
 
     /** Get the title of the content */
     virtual QString getTitle() const;

--- a/tide/core/scene/ContentFactory.cpp
+++ b/tide/core/scene/ContentFactory.cpp
@@ -43,6 +43,10 @@
 #include "log.h"
 
 #include "Content.h"
+#include "ErrorContent.h"
+#include "PixelStreamContent.h"
+#include "SVGContent.h"
+#include "TextureContent.h"
 #if TIDE_USE_TIFF
 #include "ImagePyramidContent.h"
 #include "data/TiffPyramidReader.h"
@@ -53,9 +57,6 @@
 #if TIDE_ENABLE_PDF_SUPPORT
 #include "PDFContent.h"
 #endif
-#include "PixelStreamContent.h"
-#include "SVGContent.h"
-#include "TextureContent.h"
 #if TIDE_ENABLE_WEBBROWSER_SUPPORT
 #include "WebbrowserContent.h"
 #endif
@@ -64,8 +65,6 @@
 #include <QFileInfo>
 #include <QImageReader>
 #include <QTextStream>
-
-#define ERROR_IMAGE_FILENAME ":/img/error.png"
 
 namespace
 {
@@ -96,19 +95,6 @@ ContentPtr _makeContent(const QString& uri)
         return nullptr;
     }
 }
-
-class ErrorContent : public TextureContent
-{
-public:
-    ErrorContent(const QSize& size)
-        : TextureContent(ERROR_IMAGE_FILENAME)
-    {
-        if (!size.isEmpty())
-            setDimensions(size);
-        else
-            readMetadata();
-    }
-};
 }
 
 CONTENT_TYPE ContentFactory::getContentTypeForFile(const QString& uri)
@@ -191,9 +177,17 @@ ContentPtr ContentFactory::getPixelStreamContent(const QString& uri,
     }
 }
 
-ContentPtr ContentFactory::getErrorContent(const QSize& size)
+ContentPtr ContentFactory::getErrorContent(const Content& content)
 {
-    return std::make_unique<ErrorContent>(size);
+    const auto& uri = content.getURI();
+    const auto& size = content.getDimensions();
+
+    return std::make_unique<ErrorContent>(uri, size);
+}
+
+ContentPtr ContentFactory::getErrorContent(const QString& uri)
+{
+    return std::make_unique<ErrorContent>(uri, QSize());
 }
 
 const QStringList& ContentFactory::getSupportedExtensions()

--- a/tide/core/scene/ContentFactory.h
+++ b/tide/core/scene/ContentFactory.h
@@ -58,7 +58,10 @@ public:
         StreamType stream = StreamType::EXTERNAL);
 
     /** Get a Content object representing a loading error. */
-    static ContentPtr getErrorContent(const QSize& size = QSize());
+    static ContentPtr getErrorContent(const Content& content);
+
+    /** For legacy sessions; deprecated. */
+    static ContentPtr getErrorContent(const QString& uri);
 
     /** Get all the supported file extensions. */
     static const QStringList& getSupportedExtensions();

--- a/tide/core/scene/ErrorContent.cpp
+++ b/tide/core/scene/ErrorContent.cpp
@@ -1,8 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2018, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -39,11 +37,26 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#include "DynamicTextureContent.h"
+#include "ErrorContent.h"
 
-BOOST_CLASS_EXPORT(DynamicTextureContent)
+BOOST_CLASS_EXPORT(ErrorContent)
 
-CONTENT_TYPE DynamicTextureContent::getType() const
+namespace
 {
-    return CONTENT_TYPE_DYNAMIC_TEXTURE;
+const auto ERROR_IMAGE_FILENAME = ":/img/error.png";
+}
+
+ErrorContent::ErrorContent(const QString& uri, const QSize& size)
+    : TextureContent(ERROR_IMAGE_FILENAME)
+    , _originalUri{uri}
+{
+    if (!size.isEmpty())
+        setDimensions(size);
+    else
+        readMetadata();
+}
+
+QString ErrorContent::getFilePath() const
+{
+    return _originalUri;
 }

--- a/tide/core/scene/ErrorContent.h
+++ b/tide/core/scene/ErrorContent.h
@@ -1,8 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2011 - 2012, The University of Texas at Austin.     */
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
-/*                     Raphael.Dumusc@epfl.ch                        */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2018, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -39,11 +37,45 @@
 /* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#include "DynamicTextureContent.h"
+#ifndef ERROR_CONTENT_H
+#define ERROR_CONTENT_H
 
-BOOST_CLASS_EXPORT(DynamicTextureContent)
+#include "TextureContent.h"
 
-CONTENT_TYPE DynamicTextureContent::getType() const
+/**
+ * A placeholder to replace a Content that can no longer be restored from file.
+ *
+ * Error contents are not kept when saving the session again.
+ */
+class ErrorContent : public TextureContent
 {
-    return CONTENT_TYPE_DYNAMIC_TEXTURE;
-}
+public:
+    /**
+     * Constructor.
+     * @param uri The uri of the original content.
+     * @param size The size of the original content.
+     */
+    ErrorContent(const QString& uri, const QSize& size);
+
+    /** @return the uri of the original content. */
+    QString getFilePath() const override;
+
+private:
+    QString _originalUri;
+
+    friend class boost::serialization::access;
+
+    ErrorContent() = default; // required for boost::serialization
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int)
+    {
+        // serialize base class information (with NVP for xml archives)
+        // clang-format off
+        ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(TextureContent);
+        ar & boost::serialization::make_nvp("originalUri", _originalUri);
+        // clang-format on
+    }
+};
+
+#endif

--- a/tide/core/scene/ImagePyramidContent.cpp
+++ b/tide/core/scene/ImagePyramidContent.cpp
@@ -41,7 +41,7 @@
 
 #include "data/TiffPyramidReader.h"
 
-BOOST_CLASS_EXPORT_GUID(ImagePyramidContent, "ImagePyramidContent")
+BOOST_CLASS_EXPORT(ImagePyramidContent)
 
 ImagePyramidContent::ImagePyramidContent(const QString& uri)
     : Content(uri)

--- a/tide/core/scene/SVGContent.cpp
+++ b/tide/core/scene/SVGContent.cpp
@@ -45,7 +45,7 @@
 
 #include <QFileInfo>
 
-BOOST_CLASS_EXPORT_GUID(SVGContent, "SVGContent")
+BOOST_CLASS_EXPORT(SVGContent)
 
 SVGContent::SVGContent(const QString& uri)
     : VectorialContent(uri)

--- a/tide/core/scene/TextureContent.cpp
+++ b/tide/core/scene/TextureContent.cpp
@@ -43,7 +43,7 @@
 
 #include <QImageReader>
 
-BOOST_CLASS_EXPORT_GUID(TextureContent, "TextureContent")
+BOOST_CLASS_EXPORT_IMPLEMENT(TextureContent)
 
 TextureContent::TextureContent(const QString& uri)
     : Content(uri)

--- a/tide/core/scene/TextureContent.h
+++ b/tide/core/scene/TextureContent.h
@@ -67,11 +67,12 @@ public:
 
     static const QStringList& getSupportedExtensions();
 
+protected:
+    TextureContent() = default; // required for boost::serialization
+
 private:
     friend class boost::serialization::access;
 
-    // Default constructor required for boost::serialization
-    TextureContent() {}
     template <class Archive>
     void serialize(Archive& ar, const unsigned int)
     {
@@ -81,5 +82,8 @@ private:
         // clang-format on
     }
 };
+
+// Need to be in header for serialization of derived class ErrorContent
+BOOST_CLASS_EXPORT_KEY(TextureContent)
 
 #endif

--- a/tide/master/State.cpp
+++ b/tide/master/State.cpp
@@ -77,7 +77,7 @@ ContentPtr _loadContent(XmlParser& parser, const QString& index)
     if (parser.get(query.arg(index, "URI"), uri))
         content = ContentFactory::getContent(uri);
     if (!content)
-        content = ContentFactory::getErrorContent();
+        content = ContentFactory::getErrorContent(uri);
 
     return content;
 }

--- a/tide/master/StateSerializationHelper.h
+++ b/tide/master/StateSerializationHelper.h
@@ -77,7 +77,7 @@ public:
      *
      * @return the loaded scene on success, nullptr on failure.
      */
-    QFuture<SceneConstPtr> load(const QString& filename) const;
+    QFuture<ScenePtr> load(const QString& filename) const;
 
     /**
      * Find an available filename by appending "_[n]" if needed to the filename.

--- a/tide/master/control/SceneController.cpp
+++ b/tide/master/control/SceneController.cpp
@@ -60,16 +60,15 @@ SceneController::SceneController(Scene& scene_,
                 &SceneController::_deleteTempContentFile);
     }
 
-    connect(&_loadSessionOp, &QFutureWatcher<SceneConstPtr>::finished,
-            [this]() {
-                auto scene = _loadSessionOp.result();
-                if (scene)
-                    apply(scene);
+    connect(&_loadSessionOp, &QFutureWatcher<ScenePtr>::finished, [this]() {
+        auto scene = _loadSessionOp.result();
+        if (scene)
+            apply(scene);
 
-                if (_loadSessionCallback)
-                    _loadSessionCallback(scene != nullptr);
-                _loadSessionCallback = nullptr;
-            });
+        if (_loadSessionCallback)
+            _loadSessionCallback(scene != nullptr);
+        _loadSessionCallback = nullptr;
+    });
 
     connect(&_saveSessionOp, &QFutureWatcher<bool>::finished, [this]() {
         if (_saveSessionCallback)

--- a/tide/master/control/SceneController.h
+++ b/tide/master/control/SceneController.h
@@ -80,7 +80,7 @@ private:
     Scene& _scene;
     Configuration::Folders _folders;
 
-    QFutureWatcher<SceneConstPtr> _loadSessionOp;
+    QFutureWatcher<ScenePtr> _loadSessionOp;
     QFutureWatcher<bool> _saveSessionOp;
     BoolCallback _loadSessionCallback;
     BoolCallback _saveSessionCallback;

--- a/tide/master/ui/MasterWindow.cpp
+++ b/tide/master/ui/MasterWindow.cpp
@@ -93,15 +93,13 @@ MasterWindow::MasterWindow(ScenePtr scene_, OptionsPtr options,
             });
 #endif
 
-    connect(&_loadSessionOp, &QFutureWatcher<SceneConstPtr>::finished,
-            [this]() {
-                if (auto scene = _loadSessionOp.result())
-                    emit sessionLoaded(scene);
-                else
-                    QMessageBox::warning(this, "Error",
-                                         "Could not load session file.",
-                                         QMessageBox::Ok, QMessageBox::Ok);
-            });
+    connect(&_loadSessionOp, &QFutureWatcher<ScenePtr>::finished, [this]() {
+        if (auto scene = _loadSessionOp.result())
+            emit sessionLoaded(scene);
+        else
+            QMessageBox::warning(this, "Error", "Could not load session file.",
+                                 QMessageBox::Ok, QMessageBox::Ok);
+    });
 
     connect(&_saveSessionOp, &QFutureWatcher<bool>::finished, [this]() {
         if (!_saveSessionOp.result())

--- a/tide/master/ui/MasterWindow.h
+++ b/tide/master/ui/MasterWindow.h
@@ -76,7 +76,7 @@ signals:
     void openWhiteboard(uint surfaceIndex);
 
     /** Emitted when a session has been successfully loaded. */
-    void sessionLoaded(SceneConstPtr group);
+    void sessionLoaded(ScenePtr group);
 
 protected:
     /** @name Drag events re-implemented from QMainWindow */
@@ -112,7 +112,7 @@ private:
     ScenePtr _scene;
     OptionsPtr _options;
 
-    QFutureWatcher<SceneConstPtr> _loadSessionOp;
+    QFutureWatcher<ScenePtr> _loadSessionOp;
     QFutureWatcher<bool> _saveSessionOp;
 
     BackgroundWidget* _backgroundWidget; // child QObject


### PR DESCRIPTION
- Display the title / file path of the original content.
- Don't save error contents in sessions.
- Fix a crash introduced in 8e0c713 (missing boost::serialization for ErrorContent class).