### PR TITLE
Fix a possible segfault with side-by-side movies

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.4.1 (git 1.4)
 
+* [263](https://github.com/BlueBrain/Tide/pull/263):
+  Fix a crash that could occur when playing large 3D movies.
 * [252](https://github.com/BlueBrain/Tide/pull/252):
   - Fix movie duration calculation.
   - Fix occasional crash when generating thumbnails for small movies.

--- a/tide/wall/MovieUpdater.cpp
+++ b/tide/wall/MovieUpdater.cpp
@@ -50,15 +50,14 @@
 
 namespace
 {
-void _splitSideBySide(const FFMPEGPicture& image, PicturePtr& left,
-                      PicturePtr& right)
+std::pair<PicturePtr, PicturePtr> _splitSideBySide(const FFMPEGPicture& image)
 {
     const auto width = image.getWidth() / 2;
     const auto height = image.getHeight();
     const auto format = image.getFormat();
 
-    left = std::make_shared<FFMPEGPicture>(width, height, format);
-    right = std::make_shared<FFMPEGPicture>(width, height, format);
+    auto left = std::make_shared<FFMPEGPicture>(width, height, format);
+    auto right = std::make_shared<FFMPEGPicture>(width, height, format);
 
     const uint numTextures = (format == TextureFormat::rgba) ? 1 : 3 /*YUV*/;
     for (uint texture = 0; texture < numTextures; ++texture)
@@ -75,6 +74,15 @@ void _splitSideBySide(const FFMPEGPicture& image, PicturePtr& left,
             std::copy(input + targetWidth, input + lineWidth, outRight);
         }
     }
+    return std::make_pair(left, right);
+}
+
+std::pair<PicturePtr, PicturePtr> _splitSideBySide(
+    std::shared_ptr<FFMPEGPicture> image)
+{
+    if (!image)
+        return std::make_pair(image, image);
+    return _splitSideBySide(*image);
 }
 }
 
@@ -145,6 +153,8 @@ ImagePtr MovieUpdater::getTileImage(const uint tileIndex,
     if (loopBack)
         image = _ffmpegMovie->getFrame(0.0);
 
+    // Warning: in rare cases image may still be null at this point
+
     {
         const QMutexLocker lock(&_mutex);
         _currentPosition = _ffmpegMovie->getPosition();
@@ -155,7 +165,7 @@ ImagePtr MovieUpdater::getTileImage(const uint tileIndex,
     }
     if (_ffmpegMovie->isStereo())
     {
-        _splitSideBySide(*image, _pictureLeftOrMono, _pictureRight);
+        std::tie(_pictureLeftOrMono, _pictureRight) = _splitSideBySide(image);
         return view == deflect::View::right_eye ? _pictureRight
                                                 : _pictureLeftOrMono;
     }


### PR DESCRIPTION
It was possible that the left & right PicturePtr& were reset concurrently by _triggerFrameUpdate() while a getTileImage() was still in progress, causing a segfault in left->getData(texture).

The crash could be reproduced within seconds by opening a large 3D movie and moving the window around.

Due to the complexity of the movie decoding code there may still be a different logical problem somewhere; but the segfault no longer occurs.