### PR TITLE
Fix segfault affecting resizing of large streams with small tiles

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#changelog}
 
 # Release 1.5 (git master)
 
+* [275](https://github.com/BlueBrain/Tide/pull/275):
+  Fix a crash that could occur when resizing large pixel streams.
 * [272](https://github.com/BlueBrain/Tide/pull/272):
   - Smooth transitions between resolution levels for opaque contents (PDFs,
     regular TIFF pyramids).

--- a/tide/wall/datasources/PixelStreamUpdater.h
+++ b/tide/wall/datasources/PixelStreamUpdater.h
@@ -113,10 +113,12 @@ private:
     std::unique_ptr<PixelStreamProcessor> _processorLeft;
     std::unique_ptr<PixelStreamProcessor> _processRight;
     mutable QReadWriteLock _frameMutex;
+    mutable std::unique_ptr<std::vector<std::mutex>> _perTileLock;
     bool _readyToSwap = true;
 
     void _onFrameSwapped(deflect::server::FramePtr frame);
     void _createFrameProcessors();
+    void _createPerTileMutexes();
 };
 
 #endif

--- a/tide/wall/tools/PixelStreamAssembler.cpp
+++ b/tide/wall/tools/PixelStreamAssembler.cpp
@@ -39,6 +39,8 @@
 
 #include "PixelStreamAssembler.h"
 
+#include <numeric> // std::accumulate
+
 namespace
 {
 Indices _mapToGlobalIndices(const Indices& perChannelIndices,
@@ -58,7 +60,7 @@ PixelStreamAssembler::PixelStreamAssembler(deflect::server::FramePtr frame)
 }
 
 ImagePtr PixelStreamAssembler::getTileImage(
-    uint tileIndex, deflect::server::TileDecoder& decoder)
+    const uint tileIndex, deflect::server::TileDecoder& decoder)
 {
     const auto& channel = _getChannel(tileIndex);
     return channel.assembler.getTileImage(tileIndex - channel.offset, decoder);
@@ -77,6 +79,14 @@ Indices PixelStreamAssembler::computeVisibleSet(const QRectF& visibleArea,
     const auto indices =
         channel.assembler.computeVisibleSet(visibleArea, channelIndex);
     return _mapToGlobalIndices(indices, channel.offset);
+}
+
+size_t PixelStreamAssembler::getTilesCount() const
+{
+    return std::accumulate(_channels.begin(), _channels.end(), 0u,
+                           [](const auto count, const Channel& channel) {
+                               return count + channel.tilesCount;
+                           });
 }
 
 bool PixelStreamAssembler::_parseChannels(deflect::server::FramePtr frame)

--- a/tide/wall/tools/PixelStreamAssembler.h
+++ b/tide/wall/tools/PixelStreamAssembler.h
@@ -77,6 +77,9 @@ public:
     Indices computeVisibleSet(const QRectF& visibleArea,
                               uint channel) const final;
 
+    /** @copydoc PixelStreamProcessor::getTilesCount */
+    size_t getTilesCount() const final;
+
 private:
     struct Channel
     {

--- a/tide/wall/tools/PixelStreamChannelAssembler.cpp
+++ b/tide/wall/tools/PixelStreamChannelAssembler.cpp
@@ -130,7 +130,7 @@ Indices PixelStreamChannelAssembler::computeVisibleSet(
     return visibleSet;
 }
 
-uint PixelStreamChannelAssembler::getTilesCount() const
+size_t PixelStreamChannelAssembler::getTilesCount() const
 {
     return _getTilesX() * _getTilesY();
 }

--- a/tide/wall/tools/PixelStreamChannelAssembler.h
+++ b/tide/wall/tools/PixelStreamChannelAssembler.h
@@ -78,8 +78,8 @@ public:
     Indices computeVisibleSet(const QRectF& visibleArea,
                               uint channel) const final;
 
-    /** @return the number of tiles in the assembled image. */
-    uint getTilesCount() const;
+    /** @copydoc PixelStreamProcessor::getTilesCount */
+    size_t getTilesCount() const final;
 
 private:
     deflect::server::FramePtr _frame;

--- a/tide/wall/tools/PixelStreamPassthrough.cpp
+++ b/tide/wall/tools/PixelStreamPassthrough.cpp
@@ -45,7 +45,7 @@
 #include <deflect/server/TileDecoder.h>
 
 PixelStreamPassthrough::PixelStreamPassthrough(deflect::server::FramePtr frame)
-    : _frame(frame)
+    : _frame{std::move(frame)}
 {
 }
 
@@ -80,4 +80,9 @@ Indices PixelStreamPassthrough::computeVisibleSet(const QRectF& visibleArea,
             visibleSet.insert(i);
     }
     return visibleSet;
+}
+
+size_t PixelStreamPassthrough::getTilesCount() const
+{
+    return _frame->tiles.size();
 }

--- a/tide/wall/tools/PixelStreamPassthrough.h
+++ b/tide/wall/tools/PixelStreamPassthrough.h
@@ -65,6 +65,9 @@ public:
     Indices computeVisibleSet(const QRectF& visibleArea,
                               uint channel) const final;
 
+    /** @copydoc PixelStreamProcessor::getTilesCount */
+    size_t getTilesCount() const final;
+
 private:
     deflect::server::FramePtr _frame;
 };

--- a/tide/wall/tools/PixelStreamProcessor.h
+++ b/tide/wall/tools/PixelStreamProcessor.h
@@ -69,6 +69,9 @@ public:
     virtual Indices computeVisibleSet(const QRectF& visibleArea,
                                       uint channel) const = 0;
 
+    /** @return the total number of assembled tiles. */
+    virtual size_t getTilesCount() const = 0;
+
 protected:
     /** @return the coordinates of the tile as a QRect. */
     QRect toRect(const deflect::server::Tile& tile) const;


### PR DESCRIPTION
Concurrent getTileImage() calls for the same tileIndex can occur unexpectedly when resizing a stream window. Adding a per-tile mutex is the simplest way to fix the problem and should not penalize performance too much as those events are rare. Returning an empty ImagePtr does not work (the stream blocks).